### PR TITLE
Remove the guess run for Noah MP LSM

### DIFF
--- a/physics/GFS_surface_loop_control.F90
+++ b/physics/GFS_surface_loop_control.F90
@@ -31,7 +31,8 @@
       implicit none
 
       ! Interface variables
-      integer, intent(in)                                :: im,lsm,lsm_noahmp
+      integer, intent(in)                                :: im
+      integer, intent(in)                                :: lsm,lsm_noahmp
       integer, intent(in)                                :: iter
       real(kind=kind_phys), dimension(im), intent(in)    :: wind
       logical,              dimension(im), intent(inout) :: flag_guess
@@ -88,7 +89,8 @@
       implicit none
 
       ! Interface variables
-      integer,                             intent(in)    :: im,lsm,lsm_noahmp
+      integer,                             intent(in)    :: im
+      integer,                             intent(in)    :: lsm,lsm_noahmp
       integer,                             intent(in)    :: iter
 
       real(kind=kind_phys), dimension(im), intent(in)    :: wind

--- a/physics/GFS_surface_loop_control.F90
+++ b/physics/GFS_surface_loop_control.F90
@@ -24,14 +24,14 @@
 !!  \section detailed Detailed Algorithm
 !!  @{
 
-      subroutine GFS_surface_loop_control_part1_run (im, iter, wind, flag_guess, errmsg, errflg)
+      subroutine GFS_surface_loop_control_part1_run (im,lsm,lsm_noahmp, iter, wind, flag_guess, errmsg, errflg)
 
       use machine,           only: kind_phys
 
       implicit none
 
       ! Interface variables
-      integer, intent(in)                                :: im
+      integer, intent(in)                                :: im,lsm,lsm_noahmp
       integer, intent(in)                                :: iter
       real(kind=kind_phys), dimension(im), intent(in)    :: wind
       logical,              dimension(im), intent(inout) :: flag_guess
@@ -47,7 +47,7 @@
       errflg = 0
 
       do i=1,im
-        if (iter == 1 .and. wind(i) < 2.0d0) then
+        if (iter == 1 .and. wind(i) < 2.0d0 .and. lsm /= lsm_noahmp) then
           flag_guess(i) = .true.
         endif
       enddo
@@ -80,7 +80,7 @@
 !!  \section detailed Detailed Algorithm
 !!  @{
 
-      subroutine GFS_surface_loop_control_part2_run (im, iter,  wind, &
+      subroutine GFS_surface_loop_control_part2_run (im, lsm,lsm_noahmp,iter,  wind, &
              flag_guess, flag_iter, dry, wet, icy, nstf_name1, errmsg, errflg)
 
       use machine,           only: kind_phys
@@ -88,8 +88,9 @@
       implicit none
 
       ! Interface variables
-      integer,                             intent(in)    :: im
+      integer,                             intent(in)    :: im,lsm,lsm_noahmp
       integer,                             intent(in)    :: iter
+
       real(kind=kind_phys), dimension(im), intent(in)    :: wind
       logical,              dimension(im), intent(inout) :: flag_guess
       logical,              dimension(im), intent(inout) :: flag_iter
@@ -112,10 +113,11 @@
 
         if (iter == 1 .and. wind(i) < 2.0d0) then
           !if (dry(i) .or. (wet(i) .and. .not.icy(i) .and. nstf_name1 > 0)) then
-          if (dry(i) .or. (wet(i) .and. nstf_name1 > 0)) then
+          if ((dry(i) .and. lsm /= lsm_noahmp) .or. (wet(i) .and. nstf_name1 > 0)) then
             flag_iter(i) = .true.
           endif
         endif
+
 
       enddo
 

--- a/physics/GFS_surface_loop_control.meta
+++ b/physics/GFS_surface_loop_control.meta
@@ -15,6 +15,22 @@
   type = integer
   intent = in
   optional = F
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_noahmp]
+  standard_name = flag_for_noahmp_land_surface_scheme
+  long_name = flag for NOAH MP land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [iter]
   standard_name = ccpp_loop_counter
   long_name = loop counter for subcycling loops in CCPP
@@ -76,6 +92,23 @@
   type = integer
   intent = in
   optional = F
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_noahmp]
+  standard_name = flag_for_noahmp_land_surface_scheme
+  long_name = flag for NOAH MP land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+
 [iter]
   standard_name = ccpp_loop_counter
   long_name = loop counter for subcycling loops in CCPP

--- a/physics/GFS_surface_loop_control.meta
+++ b/physics/GFS_surface_loop_control.meta
@@ -108,7 +108,6 @@
   type = integer
   intent = in
   optional = F
-
 [iter]
   standard_name = ccpp_loop_counter
   long_name = loop counter for subcycling loops in CCPP

--- a/physics/module_sf_noahmp_glacier.f90
+++ b/physics/module_sf_noahmp_glacier.f90
@@ -115,7 +115,7 @@ contains
 !>\ingroup NoahMP_LSM
   subroutine noahmp_glacier (&
                    iloc    ,jloc    ,cosz    ,nsnow   ,nsoil   ,dt      , & ! in : time/space/model-related
-                   sfctmp  ,sfcprs  ,uu      ,vv      ,q2      ,soldn   , & ! in : forcing
+                   sfctmp  ,thair   ,sfcprs  ,uu      ,vv      ,q2      ,soldn   , & ! in : forcing
                    prcp    ,lwdn    ,tbot    ,zlvl    ,ficeold ,zsoil   , & ! in : forcing
                    qsnow   ,sneqvo  ,albold  ,cm      ,ch      ,isnow   , & ! in/out : 
                    sneqv   ,smc     ,zsnso   ,snowh   ,snice   ,snliq   , & ! in/out :
@@ -216,6 +216,7 @@ contains
   integer, dimension(-nsnow+1:nsoil)             :: imelt  !phase change index [1-melt; 2-freeze]
   real (kind=kind_phys)                                           :: rhoair !density air (kg/m3)
   real (kind=kind_phys), dimension(-nsnow+1:nsoil)                :: dzsnso !snow/soil layer thickness [m]
+  !real (kind=kind_phys)                                           :: thair  !potential temperature (k)
   real (kind=kind_phys)                                           :: thair  !potential temperature (k)
   real (kind=kind_phys)                                           :: qair   !specific humidity (kg/kg) (q2/(1+q2))
   real (kind=kind_phys)                                           :: eair   !vapor pressure air (pa)
@@ -238,7 +239,7 @@ contains
 ! --------------------------------------------------------------------------------------------------
 ! re-process atmospheric forcing
 
-   call atm_glacier (sfcprs ,sfctmp ,q2     ,soldn  ,cosz   ,thair  , & 
+   call atm_glacier (sfcprs ,sfctmp ,q2     ,soldn  ,cosz   , & 
                      qair   ,eair   ,rhoair ,solad  ,solai  ,swdown )
 
    beg_wb = sneqv
@@ -330,7 +331,7 @@ contains
   end subroutine noahmp_glacier
 ! ==================================================================================================
 !>\ingroup NoahMP_LSM
-  subroutine atm_glacier (sfcprs ,sfctmp ,q2     ,soldn  ,cosz   ,thair  , &
+  subroutine atm_glacier (sfcprs ,sfctmp ,q2     ,soldn  ,cosz   , &
                           qair   ,eair   ,rhoair ,solad  ,solai  , &
                           swdown )     
 ! --------------------------------------------------------------------------------------------------
@@ -348,7 +349,7 @@ contains
 
 ! outputs
 
-  real (kind=kind_phys)                          , intent(out) :: thair  !potential temperature (k)
+! real (kind=kind_phys)                          , intent(out) :: thair  !potential temperature (k)
   real (kind=kind_phys)                          , intent(out) :: qair   !specific humidity (kg/kg) (q2/(1+q2))
   real (kind=kind_phys)                          , intent(out) :: eair   !vapor pressure air (pa)
   real (kind=kind_phys), dimension(       1:   2), intent(out) :: solad  !incoming direct solar radiation (w/m2)
@@ -362,7 +363,7 @@ contains
 ! --------------------------------------------------------------------------------------------------
 
        pair   = sfcprs                   ! atm bottom level pressure (pa)
-       thair  = sfctmp * (sfcprs/pair)**(rair/cpair) 
+!      thair  = sfctmp * (sfcprs/pair)**(rair/cpair) 
 !       qair   = q2 / (1.0+q2)           ! mixing ratio to specific humidity [kg/kg]
        qair   = q2                       ! in wrf, driver converts to specific humidity
 

--- a/physics/module_sf_noahmp_glacier.f90
+++ b/physics/module_sf_noahmp_glacier.f90
@@ -1256,28 +1256,28 @@ contains
         evb   = cev * (estg*rhsur - eair        )
         ghb   = cgh * (tgb        - stc(isnow+1))
 
-!       b     = sag-irb-shb-evb-ghb
-!       a     = 4.*cir*tgb**3 + csh + cev*destg + cgh
-!       dtg   = b/a
+        b     = sag-irb-shb-evb-ghb
+        a     = 4.*cir*tgb**3 + csh + cev*destg + cgh
+        dtg   = b/a
 
-!       irb = irb + 4.*cir*tgb**3*dtg
-!       shb = shb + csh*dtg
-!       evb = evb + cev*destg*dtg
-!       ghb = ghb + cgh*dtg
+        irb = irb + 4.*cir*tgb**3*dtg
+        shb = shb + csh*dtg
+        evb = evb + cev*destg*dtg
+        ghb = ghb + cgh*dtg
 
 ! update ground surface temperature
-!       tgb = tgb + dtg
+        tgb = tgb + dtg
 
 ! for m-o length
-!       h = csh * (tgb - sfctmp)
+        h = csh * (tgb - sfctmp)
 
-!       t = tdc(tgb)
-!       call esat(t, esatw, esati, dsatw, dsati)
-!       if (t .gt. 0.) then
-!           estg  = esatw
-!       else
-!           estg  = esati
-!       end if
+        t = tdc(tgb)
+        call esat(t, esatw, esati, dsatw, dsati)
+        if (t .gt. 0.) then
+            estg  = esatw
+        else
+            estg  = esati
+        end if
 !
         qsfc = 0.622*(estg*rhsur)/(sfcprs-0.378*(estg*rhsur))
 

--- a/physics/module_sf_noahmplsm.f90
+++ b/physics/module_sf_noahmplsm.f90
@@ -3929,7 +3929,7 @@ endif   ! croptype == 0
           cm = cm / ur
        endif
 
-      if (opt_sfc == 3 ) then
+      if (opt_sfc == 3 .and. iter == 1) then
 
            sigmaa    = 1.0 - (0.5/(0.5+vaie))*exp(-vaie**2/8.0)
            kbsigmaf1 = 16.4*(sigmaa*vaie**3)**(-0.25)*sqrt(dlf*ur/log((zlvl-zpd)/z0m))
@@ -4542,27 +4542,27 @@ endif   ! croptype == 0
         evb   = cev * (estg*rhsur - eair        )
         ghb   = cgh * (tgb        - stc(isnow+1))
 
-!       b     = sag-irb-shb-evb-ghb+pahb
-!       a     = 4.*cir*tgb**3 + csh + cev*destg + cgh
-!       dtg   = b/a
+        b     = sag-irb-shb-evb-ghb+pahb
+        a     = 4.*cir*tgb**3 + csh + cev*destg + cgh
+        dtg   = b/a
 
-!       irb = irb + 4.*cir*tgb**3*dtg
-!       shb = shb + csh*dtg
-!       evb = evb + cev*destg*dtg
-!       ghb = ghb + cgh*dtg
+        irb = irb + 4.*cir*tgb**3*dtg
+        shb = shb + csh*dtg
+        evb = evb + cev*destg*dtg
+        ghb = ghb + cgh*dtg
 
 ! update ground surface temperature
-!       tgb = tgb + dtg
+        tgb = tgb + dtg
 ! for m-o length
-!       h = csh * (tgb - sfctmp)
+        h = csh * (tgb - sfctmp)
 
-!       t = tdc(tgb)
-!       call esat(t, esatw, esati, dsatw, dsati)
-!       if (t .gt. 0.) then
-!           estg  = esatw
-!       else
-!           estg  = esati
-!       end if
+        t = tdc(tgb)
+        call esat(t, esatw, esati, dsatw, dsati)
+        if (t .gt. 0.) then
+            estg  = esatw
+        else
+            estg  = esati
+        end if
         qsfc = 0.622*(estg*rhsur)/(psfc-0.378*(estg*rhsur))
 
         qfx = (qsfc-qair)*cev*gamma/cpair

--- a/physics/sfc_diag_post.F90
+++ b/physics/sfc_diag_post.F90
@@ -42,14 +42,14 @@
         errmsg = ''
         errflg = 0
 
-        if (lsm == lsm_noahmp) then
-          do i=1,im
-            if(dry(i)) then
-              t2m(i) = t2mmp(i)
-              q2m(i) = q2mp(i)
-            endif
-          enddo
-        endif
+!       if (lsm == lsm_noahmp) then
+!         do i=1,im
+!           if(dry(i)) then
+!             t2m(i) = t2mmp(i)
+!             q2m(i) = q2mp(i)
+!           endif
+!         enddo
+!       endif
 
         if (lssav) then
           do i=1,im

--- a/physics/sfc_diff.f
+++ b/physics/sfc_diff.f
@@ -10,7 +10,7 @@
 
       implicit none
 
-      public :: sfc_diff_init, sfc_diff_run, sfc_diff_finalize
+      public :: sfc_diff_init, sfc_diff_run,stability, sfc_diff_finalize
 
       private
 

--- a/physics/sfc_noahmp_drv.F90
+++ b/physics/sfc_noahmp_drv.F90
@@ -98,7 +98,7 @@
     ( im, km, itime, ps, u1, v1, t1, q1, soiltyp, vegtype,       &
       sigmaf, dlwflx, dswsfc, snet, delt, tg3, cm, ch,           &
       prsl1, prslki, zf, dry, wind, slopetyp,                    &
-      shdmin, shdmax, snoalb, sfalb, flag_iter, flag_guess,      &
+      shdmin, shdmax, snoalb, sfalb, flag_iter,                  &
       idveg, iopt_crs, iopt_btr, iopt_run, iopt_sfc, iopt_frz,   &
       iopt_inf, iopt_rad, iopt_alb, iopt_snf, iopt_tbot,         &
       iopt_stc, xlatin, xcoszin, iyrlen, julian,                 &
@@ -108,7 +108,7 @@
 
 !  ---  in/outs:
       weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        &
-      canopy, trans, tsurf, zorl,                                &
+      canopy, trans, zorl,                                       &
 
 ! --- Noah MP specific
 
@@ -182,7 +182,6 @@
   real(kind=kind_phys), dimension(im)     , intent(in)    :: snoalb     ! upper bound on max albedo over deep snow
   real(kind=kind_phys), dimension(im)     , intent(inout) :: sfalb      ! mean surface albedo [fraction]
   logical             , dimension(im)     , intent(in)    :: flag_iter  !
-  logical             , dimension(im)     , intent(in)    :: flag_guess !
   integer                                 , intent(in)    :: idveg      ! option for dynamic vegetation
   integer                                 , intent(in)    :: iopt_crs   ! option for canopy stomatal resistance
   integer                                 , intent(in)    :: iopt_btr   ! option for soil moisture factor for stomatal resistance
@@ -223,7 +222,6 @@
   real(kind=kind_phys), dimension(im,km)  , intent(inout) :: slc        ! liquid soil moisture [m3/m3]
   real(kind=kind_phys), dimension(im)     , intent(inout) :: canopy     ! canopy moisture content [mm]
   real(kind=kind_phys), dimension(im)     , intent(inout) :: trans      ! total plant transpiration [m/s]
-  real(kind=kind_phys), dimension(im)     , intent(inout) :: tsurf      ! surface skin temperature [after iteration]
   real(kind=kind_phys), dimension(im)     , intent(inout) :: zorl       ! surface roughness [cm]
   real(kind=kind_phys), dimension(im)     , intent(inout) :: snowxy     ! actual no. of snow layers
   real(kind=kind_phys), dimension(im)     , intent(inout) :: tvxy       ! vegetation leaf temperature [K]
@@ -298,52 +296,6 @@
   integer    :: iopt_crop = 0 ! option for crop model
   integer    :: iopt_gla  = 2 ! option for glacier treatment
 
-!
-!  ---  guess iteration fields - target for removal
-!
-
-  real(kind=kind_phys), dimension(im)       :: weasd_old
-  real(kind=kind_phys), dimension(im)       :: snwdph_old
-  real(kind=kind_phys), dimension(im)       :: tskin_old
-  real(kind=kind_phys), dimension(im)       :: canopy_old
-  real(kind=kind_phys), dimension(im)       :: tprcp_old
-  real(kind=kind_phys), dimension(im)       :: srflag_old
-  real(kind=kind_phys), dimension(im)       :: snow_old
-  real(kind=kind_phys), dimension(im)       :: tv_old
-  real(kind=kind_phys), dimension(im)       :: tg_old
-  real(kind=kind_phys), dimension(im)       :: canice_old
-  real(kind=kind_phys), dimension(im)       :: canliq_old
-  real(kind=kind_phys), dimension(im)       :: eah_old
-  real(kind=kind_phys), dimension(im)       :: tah_old
-  real(kind=kind_phys), dimension(im)       :: fwet_old
-  real(kind=kind_phys), dimension(im)       :: sneqvo_old
-  real(kind=kind_phys), dimension(im)       :: albold_old
-  real(kind=kind_phys), dimension(im)       :: qsnow_old
-  real(kind=kind_phys), dimension(im)       :: wslake_old
-  real(kind=kind_phys), dimension(im)       :: zwt_old
-  real(kind=kind_phys), dimension(im)       :: wa_old
-  real(kind=kind_phys), dimension(im)       :: wt_old
-  real(kind=kind_phys), dimension(im)       :: lfmass_old
-  real(kind=kind_phys), dimension(im)       :: rtmass_old
-  real(kind=kind_phys), dimension(im)       :: stmass_old
-  real(kind=kind_phys), dimension(im)       :: wood_old
-  real(kind=kind_phys), dimension(im)       :: stblcp_old
-  real(kind=kind_phys), dimension(im)       :: fastcp_old
-  real(kind=kind_phys), dimension(im)       :: xlai_old
-  real(kind=kind_phys), dimension(im)       :: xsai_old
-  real(kind=kind_phys), dimension(im)       :: tauss_old
-  real(kind=kind_phys), dimension(im)       :: smcwtd_old
-  real(kind=kind_phys), dimension(im)       :: rech_old
-  real(kind=kind_phys), dimension(im)       :: deeprech_old
-  real(kind=kind_phys), dimension(im,   km) :: smc_old
-  real(kind=kind_phys), dimension(im,   km) :: stc_old
-  real(kind=kind_phys), dimension(im,   km) :: slc_old
-  real(kind=kind_phys), dimension(im,   km) :: smoiseq_old
-  real(kind=kind_phys), dimension(im,-2: 0) :: tsno_old  
-  real(kind=kind_phys), dimension(im,-2: 0) :: snice_old
-  real(kind=kind_phys), dimension(im,-2: 0) :: snliq_old 
-  real(kind=kind_phys), dimension(im,-2:km) :: zsnso_old
-  real(kind=kind_phys), dimension(im,-2:km) :: tsnso_old
 
 !
 !  ---  local inputs to noah-mp and glacier subroutines; listed in order in noah-mp call
@@ -543,67 +495,6 @@
   errmsg = ''
   errflg = 0
 
-!
-!  --- save land-related prognostic fields for guess run  TARGET FOR REMOVAL
-!
-  do i = 1, im
-    if (dry(i) .and. flag_guess(i)) then
-      weasd_old(i)   = weasd(i)
-      snwdph_old(i)  = snwdph(i)
-      tskin_old(i)   = tskin(i)
-      canopy_old(i)  = canopy(i)
-      tprcp_old(i)   = tprcp(i)
-      srflag_old(i)  = srflag(i)
-      snow_old(i)    = snowxy(i)
-      tv_old(i)      = tvxy(i)
-      tg_old(i)      = tgxy(i)
-      canice_old(i)  = canicexy(i)
-      canliq_old(i)  = canliqxy(i)
-      eah_old(i)     = eahxy(i)
-      tah_old(i)     = tahxy(i)
-      fwet_old(i)    = fwetxy(i)
-      sneqvo_old(i)  = sneqvoxy(i) 
-      albold_old(i)  = alboldxy(i)
-      qsnow_old(i)   = qsnowxy(i)
-      wslake_old(i)  = wslakexy(i)
-      zwt_old(i)     = zwtxy(i)
-      wa_old(i)      = waxy(i)
-      wt_old(i)      = wtxy(i)
-      lfmass_old(i)  = lfmassxy(i)
-      rtmass_old(i)  = rtmassxy(i)
-      stmass_old(i)  = stmassxy(i)
-      wood_old(i)    = woodxy(i)
-      stblcp_old(i)  = stblcpxy(i)
-      fastcp_old(i)  = fastcpxy(i)
-      xlai_old(i)    = xlaixy(i)
-      xsai_old(i)    = xsaixy(i)
-      tauss_old(i)   = taussxy(i)
-      smcwtd_old(i)  = smcwtdxy(i)
-      rech_old(i)    = rechxy(i)
-      deeprech_old(i) = deeprechxy(i)
-
-      do k = 1, km
-        smc_old(i,k)     = smc(i,k)
-        stc_old(i,k)     = stc(i,k)
-        slc_old(i,k)     = slc(i,k)
-        smoiseq_old(i,k) = smoiseq(i,k)
-      end do
-
-      do k = -2, 0
-        tsno_old(i,k)  = tsnoxy(i,k)
-        snice_old(i,k) = snicexy(i,k)
-        snliq_old(i,k) = snliqxy(i,k)
-      end do
-
-      do k = -2, km
-        zsnso_old (i,k) = zsnsoxy(i,k)
-      end do
-
-    end if  ! dry(i) .and. flag_guess(i)
-
-  end do  ! im _old loop
-
-  do i = 1, im
 
     if (flag_iter(i) .and. dry(i)) then
 
@@ -948,7 +839,6 @@
       sncovr1   (i)   = snow_cover_fraction
       qsurf     (i)   = q1(i)  + evap(i) / (con_hvap / con_cp * density * ch(i) * wind(i))     
       tskin     (i)   = temperature_radiative
-      tsurf     (i)   = temperature_radiative
       tvxy      (i)   = temperature_leaf
       tgxy      (i)   = temperature_ground
       tahxy     (i)   = temperature_canopy_air
@@ -1022,69 +912,6 @@
     end if ! flag_iter(i) .and. dry(i)
 
   end do ! im loop
-
-!
-!  --- restore land-related prognostic fields for guess run  TARGET FOR REMOVAL
-!
-
-      do i = 1, im
-        if (dry(i) .and. flag_guess(i)) then
-          weasd(i)      = weasd_old(i)
-          snwdph(i)     = snwdph_old(i)
-          tskin(i)      = tskin_old(i)
-          canopy(i)     = canopy_old(i)
-          tprcp(i)      = tprcp_old(i)
-          srflag(i)     = srflag_old(i)
-          snowxy(i)     = snow_old(i)
-          tvxy(i)       = tv_old(i)
-          tgxy(i)       = tg_old(i)
-          canicexy(i)   = canice_old(i)
-          canliqxy(i)   = canliq_old(i)
-          eahxy(i)      = eah_old(i)
-          tahxy(i)      = tah_old(i)
-          fwetxy(i)     = fwet_old(i)
-          sneqvoxy(i)   = sneqvo_old(i)
-          alboldxy(i)   = albold_old(i)
-          qsnowxy(i)    = qsnow_old(i)
-          wslakexy(i)   = wslake_old(i)
-          zwtxy(i)      = zwt_old(i)
-          waxy(i)       = wa_old(i)
-          wtxy(i)       = wt_old(i)
-          lfmassxy(i)   = lfmass_old(i)
-          rtmassxy(i)   = rtmass_old(i)
-          stmassxy(i)   = stmass_old(i)
-          woodxy(i)     = wood_old(i)
-          stblcpxy(i)   = stblcp_old(i)
-          fastcpxy(i)   = fastcp_old(i)
-          xlaixy(i)     = xlai_old(i)
-          xsaixy(i)     = xsai_old(i)
-          taussxy(i)    = tauss_old(i)
-          smcwtdxy(i)   = smcwtd_old(i)
-          rechxy(i)     = rech_old(i)
-          deeprechxy(i) = deeprech_old(i)
-
-          do k = 1, km
-            smc(i,k)     = smc_old(i,k)
-            stc(i,k)     = stc_old(i,k)
-            slc(i,k)     = slc_old(i,k)
-            smoiseq(i,k) = smoiseq_old(i,k)
-          end do
-
-          do k = -2,0
-            tsnoxy(i,k)  = tsno_old(i,k)
-            snicexy(i,k) = snice_old(i,k)
-            snliqxy(i,k) = snliq_old(i,k)
-          end do
-
-          do k = -2, km
-            zsnsoxy(i,k) =  zsnso_old(i,k)
-          end do
-       
-        else
-            tskin(i) = tsurf(i)    
-
-        end if
-      end do
 
       return
 

--- a/physics/sfc_noahmp_drv.F90
+++ b/physics/sfc_noahmp_drv.F90
@@ -108,7 +108,7 @@
 
 !  ---  in/outs:
       weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        &
-      canopy, trans, zorl,                                       &
+      canopy, trans, tsurf, zorl,                                &
 
 ! --- Noah MP specific
 
@@ -222,6 +222,7 @@
   real(kind=kind_phys), dimension(im,km)  , intent(inout) :: slc        ! liquid soil moisture [m3/m3]
   real(kind=kind_phys), dimension(im)     , intent(inout) :: canopy     ! canopy moisture content [mm]
   real(kind=kind_phys), dimension(im)     , intent(inout) :: trans      ! total plant transpiration [m/s]
+  real(kind=kind_phys), dimension(im)     , intent(inout) :: tsurf      !  surface skin temperature [after iteration]
   real(kind=kind_phys), dimension(im)     , intent(inout) :: zorl       ! surface roughness [cm]
   real(kind=kind_phys), dimension(im)     , intent(inout) :: snowxy     ! actual no. of snow layers
   real(kind=kind_phys), dimension(im)     , intent(inout) :: tvxy       ! vegetation leaf temperature [K]
@@ -841,6 +842,7 @@
       sncovr1   (i)   = snow_cover_fraction
       qsurf     (i)   = q1(i)  + evap(i) / (con_hvap / con_cp * density * ch(i) * wind(i))     
       tskin     (i)   = temperature_radiative
+      tsurf     (i)   = temperature_radiative
       tvxy      (i)   = temperature_leaf
       tgxy      (i)   = temperature_ground
       tahxy     (i)   = temperature_canopy_air

--- a/physics/sfc_noahmp_drv.F90
+++ b/physics/sfc_noahmp_drv.F90
@@ -496,6 +496,8 @@
   errflg = 0
 
 
+ do i = 1, im
+
     if (flag_iter(i) .and. dry(i)) then
 
 !

--- a/physics/sfc_noahmp_drv.meta
+++ b/physics/sfc_noahmp_drv.meta
@@ -695,6 +695,69 @@
   kind = kind_phys
   intent = inout
   optional = F
+[rb1]
+  standard_name = bulk_richardson_number_at_lowest_model_level_over_land
+  long_name = bulk Richardson number at the surface over land
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[fm1]
+  standard_name = Monin_Obukhov_similarity_function_for_momentum_over_land
+  long_name = Monin-Obukhov similarity function for momentum over land
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[fh1]
+  standard_name = Monin_Obukhov_similarity_function_for_heat_over_land
+  long_name = Monin-Obukhov similarity function for heat over land
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[ustar1]
+  standard_name = surface_friction_velocity_over_land
+  long_name = surface friction velocity over land
+  units = m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[stress1]
+  standard_name = surface_wind_stress_over_land
+  long_name = surface wind stress over land
+  units = m2 s-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[fm101]
+  standard_name = Monin_Obukhov_similarity_function_for_momentum_at_10m_over_land
+  long_name = Monin-Obukhov similarity parameter for momentum at 10m over land
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[fh21]
+  standard_name = Monin_Obukhov_similarity_function_for_heat_at_2m_over_land
+  long_name = Monin-Obukhov similarity parameter for heat at 2m over land
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [snowxy]
   standard_name = number_of_snow_layers
   long_name = number of snow layers

--- a/physics/sfc_noahmp_drv.meta
+++ b/physics/sfc_noahmp_drv.meta
@@ -330,14 +330,6 @@
   type = logical
   intent = in
   optional = F
-[flag_guess]
-  standard_name = flag_for_guess_run
-  long_name = flag for guess run
-  units = flag
-  dimensions = (horizontal_loop_extent)
-  type = logical
-  intent = in
-  optional = F
 [idveg]
   standard_name = flag_for_dynamic_vegetation_option
   long_name = choice for dynamic vegetation option (see noahmp module for definition)
@@ -680,15 +672,6 @@
   standard_name = transpiration_flux
   long_name = total plant transpiration rate
   units = W m-2
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = inout
-  optional = F
-[tsurf]
-  standard_name = surface_skin_temperature_after_iteration_over_land
-  long_name = surface skin temperature after iteration over land
-  units = K
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys

--- a/physics/sfc_noahmp_drv.meta
+++ b/physics/sfc_noahmp_drv.meta
@@ -677,6 +677,15 @@
   kind = kind_phys
   intent = inout
   optional = F
+[tsurf]
+  standard_name = surface_skin_temperature_after_iteration_over_land
+  long_name = surface skin temperature after iteration over land
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [zorl]
   standard_name = surface_roughness_length_over_land_interstitial
   long_name = surface roughness length over land  (temporary use as interstitial)


### PR DESCRIPTION
Use GFS surface loop control (suite interstitial) to set 'flag_guess' to .false. for Noah MP LSM after initial iteration, and remove corresponding in/out variables saved (and restored) for guess run purpose in the Noah MP driver, including the' flag_guess' and 'tsurf' (which is only for the iteration purpose). Necessary changes are made to the corresponding 'meta' files.