### PR TITLE
Lsm upgrades mynn for p8c

### DIFF
--- a/physics/module_sf_noahmp_glacier.f90
+++ b/physics/module_sf_noahmp_glacier.f90
@@ -7,6 +7,7 @@ module noahmp_glacier_globals
 
   use machine ,   only : kind_phys
   use sfc_diff, only   : stability
+  use module_sf_noahmplsm, only : sfcdif4
 
   implicit none
 
@@ -122,7 +123,9 @@ contains
                    iloc      ,jloc    ,cosz     ,nsnow    ,nsoil   ,dt        , & ! in : time/space/model-related
                    sfctmp    ,sfcprs  ,uu       ,vv       ,q2      ,soldn     , & ! in : forcing
                    prcp      ,lwdn    ,tbot     ,zlvl     ,ficeold ,zsoil     , & ! in : forcing
-                   thsfc_loc ,prslkix ,prsik1x  ,prslk1x  ,sigmaf1 ,garea1    , & ! in :
+                   thsfc_loc ,prslkix ,prsik1x  ,prslk1x  ,                     &
+                   psfc      ,pblhx  ,iz0tlnd   ,itime    ,                     &
+                   sigmaf1 ,garea1   ,psi_opt   ,                               & ! in :
                    qsnow     ,sneqvo  ,albold   ,cm       ,ch      ,isnow     , & ! in/out : 
                    sneqv     ,smc     ,zsnso    ,snowh    ,snice   ,snliq     , & ! in/out :
                    tg        ,stc     ,sh2o     ,tauss    ,qsfc               , & ! in/out : 
@@ -149,6 +152,8 @@ contains
   real (kind=kind_phys)                           , intent(in)    :: cosz   !< cosine solar zenith angle [0-1]
   integer                        , intent(in)    :: nsnow  !< maximum no. of snow layers        
   integer                        , intent(in)    :: nsoil  !< no. of soil layers        
+  integer                        , intent(in)    :: psi_opt
+
   real (kind=kind_phys)                           , intent(in)    :: dt     !< time step [sec]
   real (kind=kind_phys)                           , intent(in)    :: sfctmp !< surface air temperature [k]
   real (kind=kind_phys)                           , intent(in)    :: sfcprs !< pressure (pa)
@@ -166,6 +171,12 @@ contains
   real (kind=kind_phys)                           , intent(in)    :: prslkix !< pressure (pa)
   real (kind=kind_phys)                           , intent(in)    :: prsik1x !< pressure (pa)
   real (kind=kind_phys)                           , intent(in)    :: prslk1x !< pressure (pa)
+
+  real (kind=kind_phys)                           , intent(in)    :: psfc    !  surface pressure
+  real (kind=kind_phys)                           , intent(in)    :: pblhx   !  pbl height
+  integer                                         , intent(in)    :: iz0tlnd !  
+  integer                                         , intent(in)    :: itime   !< timestep
+
   real (kind=kind_phys)                           , intent(in)    :: sigmaf1 !< areal fractional cover of green vegetation 
   real (kind=kind_phys)                           , intent(in)    :: garea1  !< area of the grid cell
 
@@ -274,6 +285,7 @@ contains
                          vv        ,solad   ,solai   ,cosz    ,zlvl    ,          & !in
                          tbot      ,zbot    ,zsnso   ,dzsnso  ,sigmaf1 ,garea1  , & !in
                          thsfc_loc ,prslkix ,prsik1x ,prslk1x ,                   & !in
+                         psfc      ,pblhx     ,iz0tlnd ,itime ,psi_opt ,          &
                          tg        ,stc     ,snowh   ,sneqv   ,sneqvo  ,sh2o    , & !inout
                          smc       ,snice   ,snliq   ,albold  ,cm      ,ch      , & !inout
 #ifdef CCPP
@@ -405,6 +417,7 @@ contains
                              vv        ,solad   ,solai   ,cosz    ,zref    ,          & !in
                              tbot      ,zbot    ,zsnso   ,dzsnso  ,sigmaf1 ,garea1  , & !in
                              thsfc_loc ,prslkix ,prsik1x ,prslk1x ,                   & !in
+                             psfc      ,pblhx   ,iz0tlnd ,itime   ,psi_opt          , &
                              tg        ,stc     ,snowh   ,sneqv   ,sneqvo  ,sh2o    , & !inout
                              smc       ,snice   ,snliq   ,albold  ,cm      ,ch      , & !inout
 #ifdef CCPP
@@ -427,6 +440,8 @@ contains
 ! inputs
   integer                           , intent(in)    :: nsnow  !< maximum no. of snow layers        
   integer                           , intent(in)    :: nsoil  !< number of soil layers
+  integer                           , intent(in)    :: psi_opt
+
   integer                           , intent(in)    :: isnow  !< actual no. of snow layers
   real (kind=kind_phys)                              , intent(in)    :: dt     !< time step [sec]
   real (kind=kind_phys)                              , intent(in)    :: qsnow  !< snowfall on the ground (mm/s)
@@ -451,6 +466,12 @@ contains
   real (kind=kind_phys)                              , intent(in)    :: prslkix ! in exner function
   real (kind=kind_phys)                              , intent(in)    :: prsik1x ! in exner function
   real (kind=kind_phys)                              , intent(in)    :: prslk1x ! in exner function
+
+  real (kind=kind_phys)                              , intent(in)    :: pblhx   !< PBL height (m)
+  real (kind=kind_phys)                              , intent(in)    :: psfc    !< surface pressure
+  integer                                            , intent(in)    :: iz0tlnd !< z0t option
+  integer                                            , intent(in)    :: itime   !< integration time
+
   real (kind=kind_phys)                              , intent(in)    :: sigmaf1 !< areal fractional cover of green vegetation 
   real (kind=kind_phys)                              , intent(in)    :: garea1  !< area of the grid cell
 
@@ -561,7 +582,9 @@ contains
                        zlvl      ,zpd     ,qair    ,sfctmp  ,rhoair  ,sfcprs ,       & !in
                        ur        ,gamma   ,rsurf   ,lwdn    ,rhsur   ,smc    ,       & !in
                        eair      ,stc     ,sag     ,snowh   ,lathea  ,sh2o   ,       & !in
-                       thsfc_loc ,prslkix ,prsik1x ,prslk1x ,sigmaf1 ,garea1 ,       & !in
+                       thsfc_loc ,prslkix ,prsik1x ,prslk1x ,                        &
+                       psfc      ,pblhx   ,iz0tlnd ,itime   ,uu      ,vv     ,       &
+                       sigmaf1   ,garea1  ,psi_opt ,                                 & !in
 #ifdef CCPP
                        cm        ,ch      ,tg      ,qsfc    ,errmsg  ,errflg ,       & !inout
 #else
@@ -997,7 +1020,9 @@ contains
                            zlvl      ,zpd     ,qair    ,sfctmp  ,rhoair  ,sfcprs  ,       & !in
                            ur        ,gamma   ,rsurf   ,lwdn    ,rhsur   ,smc     ,       & !in
                            eair      ,stc     ,sag     ,snowh   ,lathea  ,sh2o    ,       & !in
-                           thsfc_loc ,prslkix ,prsik1x ,prslk1x ,sigmaf1 ,garea1  ,       & !in
+                           thsfc_loc ,prslkix ,prsik1x ,prslk1x ,                         &
+                           psfc      ,pblhx   ,iz0tlnd ,itime   ,uu      ,vv     ,        &
+                           sigmaf1   ,garea1  ,psi_opt ,                                  & !in
 #ifdef CCPP
                            cm        ,ch      ,tgb     ,qsfc    ,errmsg  ,errflg  ,       & !inout
 #else
@@ -1020,6 +1045,8 @@ contains
 ! input
   integer, intent(in)                                          :: nsnow  !< maximum no. of snow layers        
   integer, intent(in)                                          :: nsoil  !< number of soil layers
+  integer, intent(in)                                          :: psi_opt
+
   real (kind=kind_phys),                            intent(in) :: emg    !< ground emissivity
   integer,                                          intent(in) :: isnow  !< actual no. of snow layers
   real (kind=kind_phys), dimension(-nsnow+1:nsoil), intent(in) :: df     !< thermal conductivity of snow/soil (w/m/k)
@@ -1048,6 +1075,14 @@ contains
   real (kind=kind_phys),                            intent(in) :: prslkix ! in exner function
   real (kind=kind_phys),                            intent(in) :: prsik1x ! in exner function
   real (kind=kind_phys),                            intent(in) :: prslk1x ! in exner function
+
+  real (kind=kind_phys)                        , intent(in)    :: pblhx   !<
+  real (kind=kind_phys)                        , intent(in)    :: psfc    !<
+  integer                                      , intent(in)    :: iz0tlnd !<
+  integer                                      , intent(in)    :: itime   !< integration time
+  real (kind=kind_phys)                        , intent(in)    :: uu      !<
+  real (kind=kind_phys)                        , intent(in)    :: vv      !<
+
   real (kind=kind_phys),                            intent(in) :: sigmaf1 ! 
   real (kind=kind_phys),                            intent(in) :: garea1  ! 
 
@@ -1095,10 +1130,18 @@ contains
   integer                  :: iter    !< iteration index
   real (kind=kind_phys)    :: z0h     !< roughness length, sensible heat, ground (m)
 
+  real (kind=kind_phys)    :: qfx
+  real (kind=kind_phys)    :: cq2     !< surface exchange at 2m
+
+
   real(kind=kind_phys)     :: rb1i    !  bulk richardson #
   real(kind=kind_phys)     :: fm10i   !  fm10 over land ice
 
   real(kind=kind_phys)     :: stress1i!  wind stress m2 S-2
+
+  real(kind=kind_phys)     :: wspd1i
+  real(kind=kind_phys)     :: flhc1i
+  real(kind=kind_phys)     :: flqc1i
 
   real(kind=kind_phys)     :: tv1i    ! virtual potential temp @ ref level
 
@@ -1149,6 +1192,10 @@ contains
 
         h      = 0.
 
+        fh2    = 0.
+        qfx    = 0.
+
+
 ! the following only applies to opt_sfc =3, opt_sfc = 1 still done its old way
 
         snwd      = snowh*1000.0
@@ -1194,8 +1241,10 @@ contains
             tem2 = max(sigmaf1, 0.1_kind_phys)
             zvfun1= sqrt(tem1 * tem2)
             gdx=sqrt(garea1)
-     if(opt_sfc == 1 .or. opt_sfc == 2) then              !Add option for sfc scheme,use '1' for both '1'/'2'
+
+     if(opt_sfc == 1 .or. opt_sfc == 2 .or. opt_sfc == 4) then      !Add option for sfc scheme,use '1' for both '1'/'2'
       loop3: do iter = 1, niterb  ! begin stability iteration
+        if(opt_sfc == 1 .or. opt_sfc == 2) then
 
 !       for now, only allow sfcdif1 until others can be fixed
 
@@ -1211,8 +1260,45 @@ contains
 #ifdef CCPP
         if (errflg /= 0) return
 #endif
+        endif
+
+         if(opt_sfc == 4) then
+
+          call sfcdif4(1  ,1  ,uu    ,vv    ,sfctmp ,       & !allow location for use in the driver
+                      sfcprs ,psfc  ,pblhx  ,gdx   ,z0m  ,  &
+                      itime  ,snwd  ,1      ,psi_opt,       &
+                      tgb   ,qair   ,zlvl  ,iz0tlnd,qsfc ,  &  ! use zlvli?
+                      h     ,qfx    ,cm    ,ch     ,ch2  ,  &  ! ch2 = cq2 most of times
+                      cq2   ,moz    ,fv    ,rb1i, fm, fh,   &
+                     stress1i,fm10i  ,fh2  , wspd1i ,flhc1i ,flqc1i) ! some are for use in the driver call
+
+
+        ! Undo the multiplication by windspeed that SFCDIF4
+          ! applies to exchange coefficients CH and CM:
+
+          ch   = ch / wspd1i
+          cm   = cm / wspd1i
+          ch2  = ch2 / wspd1i
+          cq2  = cq2 / wspd1i
+
+          if(snwd > 0.) then
+             cm = min(0.01,cm)
+             ch = min(0.01,ch)
+             ch2 = min(0.01,ch2)
+             cq2 = min(0.01,cq2)
+          end if
+
+         endif ! 4
+
+
         ramb = max(1.,1./(cm*ur))
         rahb = max(1.,1./(ch*ur))
+
+        if(opt_sfc == 4) then
+          ramb = max(1.,1./(cm*wspd1i) )
+          rahb = max(1.,1./(ch*wspd1i) )
+        endif
+
         rawb = rahb
 
 ! es and d(es)/dt evaluated at tg
@@ -1264,6 +1350,7 @@ contains
             estg  = esati
         end if
         qsfc = 0.622*(estg*rhsur)/(sfcprs-0.378*(estg*rhsur))
+        qfx = (qsfc-qair)*cev*gamma/cpair
 
      end do loop3 ! end stability iteration
    end if
@@ -1362,6 +1449,12 @@ contains
 ! 2m air temperature
      ehb2  = fv*vkc/(log((2.+z0h)/z0h)-fh2)
      cq2b  = ehb2
+
+     if (opt_sfc == 4) then
+       ehb2 = ch2 * wspd1i ! need conductance,z0h from sfcdif4 
+       cq2b = cq2 * wspd1i ! conductance
+     endif
+
      if (ehb2.lt.1.e-5 ) then
        t2mb  = tgb
        q2b   = qsfc

--- a/physics/module_sf_noahmplsm.f90
+++ b/physics/module_sf_noahmplsm.f90
@@ -10,10 +10,22 @@ module module_sf_noahmplsm
 use machine ,   only : kind_phys
 use sfc_diff, only   : stability
 
+       use physcons, only : rcp     => con_rocp,           &
+      &                     ep_1    => con_fvirt,          &
+      &                     ep_2    => con_eps,            &
+      &                     r_d     => con_rd,             &
+      &                     cp      => con_cp,             &
+      &                     g      => con_g,               &
+      &                     xlv    => con_hvap
+
+
   implicit none
 
   public  :: noahmp_options
   public  :: noahmp_sflx
+  public  :: sfcdif4
+  public  :: psi_init
+
 
   private :: atm
   private :: phenology
@@ -373,6 +385,32 @@ use sfc_diff, only   : stability
 
   end type noahmp_parameters
 
+!
+! for sfcdif4 
+!
+   real,   parameter     :: prt=1.     !prandtl number
+   real,   parameter     :: p1000mb      = 100000.
+
+   real,   parameter     :: svp1    = 0.6112
+   real,   parameter     :: svp2    = 17.67
+   real,   parameter     :: svp3    = 29.65
+   real,   parameter     :: svpt0   = 273.15
+   real,   parameter     :: ep_3=1.-ep_2
+   real,   parameter     :: ep2=ep_2
+   real,   parameter     :: onethird = 1./3.
+   real,   parameter     :: sqrt3 = 1.7320508075688773
+   real,   parameter     :: atan1 = 0.785398163397     !in radians
+
+   real,   parameter     :: karman  = 0.4
+   real,   parameter     :: vconvc=1.25
+
+   real,   parameter     :: snowz0 = 0.011
+   real,   parameter     :: wmin   = 0.1
+
+   real,   dimension(0:1000 ),save :: psim_stab,psim_unstab, &
+                                      psih_stab,psih_unstab
+
+
 contains
 !
 !== begin noahmp_sflx ==============================================================================
@@ -385,6 +423,7 @@ contains
                    smceq   ,                                                   & ! in : vegetation/soil characteristics
                    sfctmp  , sfcprs  , psfc    , uu      , vv , q2, garea1   , & ! in : forcing
                    qc      , soldn   , lwdn,thsfc_loc, prslkix,prsik1x,prslk1x,& ! in : forcing
+                   pblhx   , iz0tlnd , itime         ,psi_opt                 ,&
 	           prcpconv, prcpnonc, prcpshcv, prcpsnow, prcpgrpl, prcphail, & ! in : forcing
                    tbot    , co2air  , o2air   , foln    , ficeold , zlvl    , & ! in : forcing
                    albold  , sneqvo  ,                                         & ! in/out : 
@@ -447,6 +486,11 @@ contains
   real (kind=kind_phys)                           , intent(in)    :: prsik1x !  in exner function
   real (kind=kind_phys)                           , intent(in)    :: prslk1x !  in exner function
   real (kind=kind_phys)                           , intent(in)    :: garea1  !  in exner function
+
+  real (kind=kind_phys)                           , intent(in)    :: pblhx   !  pbl height
+  integer                                         , intent(in)    :: iz0tlnd !< z0t option
+  integer                                         , intent(in)    :: itime   !<
+  integer                                         , intent(in)    :: psi_opt !<
 
   real (kind=kind_phys)                           , intent(inout) :: zlvl   !< reference height (m)
   real (kind=kind_phys)                           , intent(in)    :: cosz   !< cosine solar zenith angle [0-1]
@@ -682,8 +726,6 @@ contains
   logical                             :: crop_active !< flag to run crop model
 ! add canopy heat storage (C.He added based on GY Niu's communication)
   real                                :: canhs ! canopy heat storage change w/m2
-! maximum lai/sai used for some parameterizations based on plant growthi  
-
   
   ! intent (out) variables need to be assigned a value.  these normally get assigned values
   ! only if dveg == 2.
@@ -734,7 +776,7 @@ contains
 ! vegetation phenology
 
      call phenology (parameters,vegtyp ,croptype, snowh  , tv     , lat   , yearlen , julian , & !in
-                     lai  , sai  , troot  , elai    , esai   ,igs, pgs)
+                     lai    , sai    , troot  , elai    , esai   ,igs, pgs)
 
 !input gvf should be consistent with lai
      if(dveg == 1 .or. dveg == 6 .or. dveg == 7) then
@@ -778,10 +820,11 @@ contains
                  sfctmp ,thair  ,lwdn   ,uu     ,vv     ,zlvl   , & !in
                  co2air ,o2air  ,solad  ,solai  ,cosz   ,igs    , & !in
                  eair   ,tbot   ,zsnso  ,zsoil  , & !in
-                 elai   ,esai   ,fwet   ,foln   ,     & !in
+                 elai   ,esai   ,fwet   ,foln   ,         & !in
                  fveg   ,shdfac, pahv   ,pahg   ,pahb   ,             & !in
                  qsnow  ,dzsnso ,lat    ,canliq ,canice ,iloc, jloc , & !in
                  thsfc_loc, prslkix,prsik1x,prslk1x,garea1,       & !in
+                 pblhx  ,iz0tlnd, itime ,psi_opt,                 &
 		 z0wrf  ,z0hwrf ,                                 & !out
                  imelt  ,snicev ,snliqv ,epore  ,t2m    ,fsno   , & !out
                  sav    ,sag    ,qmelt  ,fsa    ,fsr    ,taux   , & !out
@@ -1057,7 +1100,7 @@ contains
 !!vegetation phenology considering vegetation canopy being buried by snow and
 !!evolution in time.
   subroutine phenology (parameters,vegtyp ,croptype, snowh  , tv     , lat   , yearlen , julian , & !in
-                        lai , sai , troot  , elai    , esai   , igs, pgs)
+                        lai    , sai    , troot  , elai    , esai   , igs, pgs)
 
 ! --------------------------------------------------------------------------------------------------
 ! vegetation phenology considering vegeation canopy being buries by snow and evolution in time
@@ -1616,10 +1659,11 @@ endif   ! croptype == 0
                      sfctmp ,thair  ,lwdn   ,uu     ,vv     ,zref   , & !in
                      co2air ,o2air  ,solad  ,solai  ,cosz   ,igs    , & !in
                      eair   ,tbot   ,zsnso  ,zsoil  , & !in
-                     elai   ,esai   ,fwet   ,foln   ,       & !in
+                     elai   ,esai   ,fwet   ,foln   ,         & !in
                      fveg   ,shdfac, pahv   ,pahg   ,pahb   ,               & !in
                      qsnow  ,dzsnso ,lat    ,canliq ,canice ,iloc   , jloc, & !in
                      thsfc_loc, prslkix,prsik1x,prslk1x,garea1,       & !in
+                     pblhx  , iz0tlnd, itime,psi_opt,                 &
 		     z0wrf  ,z0hwrf ,                                 & !out
                      imelt  ,snicev ,snliqv ,epore  ,t2m    ,fsno   , & !out
                      sav    ,sag    ,qmelt  ,fsa    ,fsr    ,taux   , & !out
@@ -1699,6 +1743,11 @@ endif   ! croptype == 0
   real (kind=kind_phys)                              , intent(in)    :: prsik1x ! in exner function
   real (kind=kind_phys)                              , intent(in)    :: prslk1x ! in exner function
   real (kind=kind_phys)                              , intent(in)    :: garea1 
+
+  real (kind=kind_phys)                              , intent(in)    :: pblhx  !  pbl height
+  integer                                            , intent(in)    :: iz0tlnd
+  integer                                            , intent(in)    :: itime
+  integer                                            , intent(in)    :: psi_opt
 
   real (kind=kind_phys)                              , intent(in)    :: qair   !specific humidity (kg/kg)
   real (kind=kind_phys)                              , intent(in)    :: sfctmp !air temperature (k)
@@ -2041,7 +2090,7 @@ endif   ! croptype == 0
   call thermoprop (parameters,nsoil   ,nsnow   ,isnow   ,ist     ,dzsnso  , & !in
                    dt      ,snowh   ,snice   ,snliq   , & !in
                    smc     ,sh2o    ,tg      ,stc     ,ur      , & !in
-                   lat     ,z0m     ,zlvl    ,vegtyp  ,  & !in
+                   lat     ,z0m     ,zlvl    ,vegtyp  , fveg, & !in
                    df      ,hcpct   ,snicev  ,snliqv  ,epore   , & !out
                    fact    )                              !out
 
@@ -2173,6 +2222,7 @@ endif   ! croptype == 0
                     foln    ,co2air  ,o2air   ,btran   ,sfcprs  , & !in
                     rhsur   ,iloc    ,jloc    ,q2      ,pahv  ,pahg  , & !in
                     thsfc_loc, prslkix,prsik1x,prslk1x, garea1,        & !in
+                    pblhx   ,iz0tlnd ,itime   ,psi_opt ,          &
                     eah     ,tah     ,tv      ,tgv     ,cmv, ustarx , & !inout
 #ifdef CCPP
                     chv     ,dx      ,dz8w    ,errmsg  ,errflg  , & !inout
@@ -2209,6 +2259,7 @@ endif   ! croptype == 0
                     emg     ,stc     ,df      ,rsurf   ,latheag  , & !in
                     gammag   ,rhsur   ,iloc    ,jloc    ,q2      ,pahb  , & !in
                     thsfc_loc, prslkix,prsik1x,prslk1x,fveg,shdfac,garea1, & !in
+                    pblhx   ,iz0tlnd ,itime   ,psi_opt ,          &
 #ifdef CCPP
                     tgb     ,cmb     ,chb, ustarx,errmsg  ,errflg   , & !inout
 #else
@@ -2260,6 +2311,11 @@ endif   ! croptype == 0
         ch    = fveg * chv       + (1.0 - fveg) * chb
         q1    = fveg * (eah*0.622/(sfcprs - 0.378*eah)) + (1.0 - fveg)*qsfc
         q2e   = fveg * q2v       + (1.0 - fveg) * q2b
+
+! effectibe skin temperature
+
+        ts    = (fveg*chv*tah + (1.0-fveg)*chb*tgb ) / ch
+
 
 ! new coupling code
 
@@ -2431,7 +2487,7 @@ endif   ! croptype == 0
   subroutine thermoprop (parameters,nsoil   ,nsnow   ,isnow   ,ist     ,dzsnso  , & !in
                          dt      ,snowh   ,snice   ,snliq   , & !in
                          smc     ,sh2o    ,tg      ,stc     ,ur      , & !in
-                         lat     ,z0m     ,zlvl    ,vegtyp  , & !in
+                         lat     ,z0m     ,zlvl    ,vegtyp  , fveg,& !in
                          df      ,hcpct   ,snicev  ,snliqv  ,epore   , & !out
                          fact    )                                       !out
 ! ------------------------------------------------------------------------------------------------- 
@@ -2456,7 +2512,8 @@ endif   ! croptype == 0
   real (kind=kind_phys),                            intent(in)  :: lat     !latitude (radians)
   real (kind=kind_phys),                            intent(in)  :: z0m     !roughness length (m)
   real (kind=kind_phys),                            intent(in)  :: zlvl    !reference height (m)
-  integer              ,                            intent(in)  :: vegtyp  !vegtyp type
+  integer                        , intent(in)  :: vegtyp  !vegtyp type
+  real (kind=kind_phys),                            intent(in)  :: fveg   !green vegetation fraction [0.0-1.0]
 
 ! outputs
   real (kind=kind_phys), dimension(-nsnow+1:nsoil), intent(out) :: df      !thermal conductivity [w/m/k]
@@ -2505,6 +2562,7 @@ endif   ! croptype == 0
 ! not in use because of the separation of the canopy layer from the ground.
 ! but this may represent the effects of leaf litter (niu comments)
 !       df1 = df1 * exp (sbeta * shdfac)
+        df(1) = df(1) * exp (sbeta * fveg)
 
 ! compute lake thermal properties 
 ! (no consideration of turbulent mixing for this version)
@@ -3650,7 +3708,7 @@ endif   ! croptype == 0
                        dt      ,sav     ,sag     ,lwdn    ,ur      , & !in
                        uu      ,vv      ,sfctmp  ,thair   ,qair    , & !in
                        eair    ,rhoair  ,snowh   ,vai     ,gammav   ,gammag,  & !in
-                       fwet    ,laisun  ,laisha  ,cwp  ,dzsnso  , & !in
+                       fwet    ,laisun  ,laisha  ,cwp     ,dzsnso  , & !in
                        zlvl    ,zpd     ,z0m     ,fveg    ,shdfac,  & !in
                        z0mg    ,emv     ,emg     ,canliq  ,fsno,          & !in
                        canice  ,stc     ,df      ,rssun   ,rssha   , & !in
@@ -3658,6 +3716,7 @@ endif   ! croptype == 0
                        foln    ,co2air  ,o2air   ,btran   ,sfcprs  , & !in
                        rhsur   ,iloc    ,jloc    ,q2      ,pahv    ,pahg     , & !in
                        thsfc_loc, prslkix,prsik1x,prslk1x, garea1,      & !in
+                       pblhx   ,iz0tlnd ,itime   ,psi_opt ,          &
                        eah     ,tah     ,tv      ,tg      ,cm,ustarx,& !inout
 #ifdef CCPP
                        ch      ,dx      ,dz8w    ,errmsg  ,errflg  , & !inout
@@ -3704,6 +3763,12 @@ endif   ! croptype == 0
   real (kind=kind_phys),                            intent(in) :: rhoair !density air (kg/m**3)
   real (kind=kind_phys),                            intent(in) :: dt     !time step (s)
   real (kind=kind_phys),                            intent(in) :: fsno     !snow fraction
+
+  real (kind=kind_phys)                           , intent(in)    :: pblhx  !  pbl height
+  integer                                         , intent(in)    :: iz0tlnd
+  integer                                         , intent(in)    :: itime
+  integer                                         , intent(in)    :: psi_opt
+
 
   real (kind=kind_phys),                            intent(in) :: snowh  !actual snow depth [m]
   real (kind=kind_phys),                            intent(in) :: fwet   !wetted fraction of canopy
@@ -3788,6 +3853,10 @@ endif   ! croptype == 0
   real (kind=kind_phys) :: wspd
 
 ! ------------------------ local variables ----------------------------------------------------
+  real (kind=kind_phys) ::  gdx         !grid dx
+  real (kind=kind_phys) ::  snwd        ! snowdepth in mm
+  integer               ::  mnice        ! MYNN ice flag
+
   real (kind=kind_phys) :: cw           !water vapor exchange coefficient
   real (kind=kind_phys) :: fv           !friction velocity (m/s)
   real (kind=kind_phys) :: wstar        !friction velocity n vertical direction (m/s) (only for sfcdif2)
@@ -3849,6 +3918,15 @@ endif   ! croptype == 0
   real (kind=kind_phys) :: fh2          !monin-obukhov heat adjustment at 2m
   real (kind=kind_phys) :: ch2          !surface exchange at 2m
   real (kind=kind_phys) :: thstar          !surface exchange at 2m
+
+  real (kind=kind_phys) :: fm10 
+  real (kind=kind_phys) :: rb1v 
+  real (kind=kind_phys) :: stress1v
+
+
+  real (kind=kind_phys) :: flhcv     ! for MYNN
+  real (kind=kind_phys) :: flqcv     ! for MYNN
+  real (kind=kind_phys) :: wspdv     ! for MYNN
 
   real (kind=kind_phys) :: thvair
   real (kind=kind_phys) :: thah 
@@ -3979,6 +4057,16 @@ endif   ! croptype == 0
 
         air = -emv*(1.+(1.-emv)*(1.-emg))*lwdn - emv*emg*sb*tg**4  
         cir = (2.-emv*(1.-emg))*emv*sb
+!
+        gdx  = sqrt(garea1)
+        snwd = snowh * 1000.0
+
+        if (snowh .gt. 0.1) then
+          mnice = 1
+        else
+          mnice = 0
+        endif
+
 ! ---------------------------------------------------------------------------------------------
       loop1: do iter = 1, niterc    !  begin stability iteration
 
@@ -4032,14 +4120,41 @@ endif   ! croptype == 0
        if(opt_sfc == 3) then
          call sfcdif3(parameters,iloc    ,jloc    ,iter    ,sfctmp  ,qair    ,ur      , & !in 
                         zlvl    ,tah     ,thsfc_loc,prslkix,prsik1x ,prslk1x ,z0m     , & !in 
-                        zpd ,snowh ,fveg ,garea1 ,.true. ,vaie ,vegtyp, & !in 
+                        zpd     ,snowh   ,shdfac  ,garea1  ,.true.  ,vaie    ,vegtyp  , & !in 
                         ustarx  ,fm      ,fh      ,fm2     ,fh2     ,                   & !inout 
                         z0h     ,fv      ,csigmaf1,cm      ,ch       )                    !out 
 
        endif
 
+        if(opt_sfc == 4) then
+
+          call sfcdif4(iloc  ,jloc  ,uu    ,vv    ,sfctmp , & 
+                      sfcprs ,psfc  ,pblhx  ,gdx  ,z0m    , &
+                      itime  ,snwd  ,mnice  ,psi_opt,      &
+                      tah   ,qair   ,zlvl  ,iz0tlnd,qsfc ,  &
+                      h     ,qfx    ,cm    ,ch     ,ch2v ,  &
+                      cq2v  ,moz    ,fv    ,rb1v, fm, fh,   &
+                     stress1v,fm10  ,fh2   ,wspdv ,flhcv ,flqcv)
+
+
+        ! Undo the multiplication by windspeed that SFCDIF4
+          ! applies to exchange coefficients CH and CM
+
+          ch   = ch / wspdv
+          cm   = cm / wspdv
+          ch2v = ch2v / wspdv
+
+       endif
+
+
        ramc = max(1.,1./(cm*ur))
        rahc = max(1.,1./(ch*ur))
+
+       if (opt_sfc == 4 ) then
+         ramc = max(1.,1./(cm*wspdv) )
+         rahc = max(1.,1./(ch*wspdv) )
+       endif
+
        rawc = rahc
 
 ! aerodyn resistance between heights z0g and d+z0v, rag, and leaf
@@ -4149,6 +4264,11 @@ endif   ! croptype == 0
 ! consistent specific humidity from canopy air vapor pressure
         qsfc = (0.622*eah)/(sfcprs-0.378*eah)
 
+        if ( opt_sfc == 4 ) then
+           qfx = (qsfc-qair)*rhoair*caw
+        endif
+
+
         if (liter == 1) then
            exit loop1 
         endif
@@ -4228,6 +4348,15 @@ endif   ! croptype == 0
       cah2 = fv*vkc/log((2.+z0h)/z0h)
       cah2 = fv*vkc/(log((2.+z0h)/z0h)-fh2)
       cq2v = cah2
+   endif
+
+    if (opt_sfc == 4 ) then
+       rahc2 = max(1.,1./(ch2v*wspdv))
+       rawc2 = rahc2
+       cah2 = 1./rahc2
+       cq2v = 1./max(1.,1./(cq2v*wspdv))
+    endif
+
       if (cah2 .lt. 1.e-5 ) then
          t2mv = tah
 !         q2v  = (eah*0.622/(sfcprs - 0.378*eah))
@@ -4237,7 +4366,6 @@ endif   ! croptype == 0
 !         q2v = (eah*0.622/(sfcprs - 0.378*eah))- qfx/(rhoair*fv)* 1./vkc * log((2.+z0h)/z0h)
          q2v = qsfc - ((evc+tr)/fveg+evg)/(latheav*rhoair) * 1./cq2v
       endif
-   endif
 
 ! update ch for output
      ch = cah
@@ -4258,6 +4386,7 @@ endif   ! croptype == 0
                         emg     ,stc     ,df      ,rsurf   ,lathea  , & !in
                         gamma   ,rhsur   ,iloc    ,jloc    ,q2      ,pahb  , & !in
                         thsfc_loc, prslkix,prsik1x,prslk1x,fveg,shdfac,garea1,  & !in
+                        pblhx  , iz0tlnd , itime  ,psi_opt            ,&
 #ifdef CCPP
                         tgb     ,cm      ,ch,ustarx,errmsg  ,errflg  , & !inout
 #else
@@ -4310,6 +4439,12 @@ endif   ! croptype == 0
   real (kind=kind_phys),                            intent(in) :: rhsur  !raltive humidity in surface soil/snow air space (-)
   real (kind=kind_phys),                            intent(in) :: fsno     !snow fraction
 
+  real (kind=kind_phys),                            intent(in) :: pblhx  !pbl height (m)
+  integer,                                          intent(in) :: iz0tlnd
+  integer,                                          intent(in) :: itime 
+  integer,                                          intent(in) :: psi_opt
+
+
 !jref:start; in 
   integer                        , intent(in) :: ivgtyp
   real (kind=kind_phys)                           , intent(in) :: qc     !cloud water mixing ratio
@@ -4350,6 +4485,19 @@ endif   ! croptype == 0
 !jref:end
 
 ! local variables 
+
+  real (kind=kind_phys) ::  gdx         !grid dx
+  real (kind=kind_phys) ::  snwd        ! snowdepth in mm
+  integer               ::  mnice       ! MYNN ice flag
+
+  real (kind=kind_phys) :: fm10
+  real (kind=kind_phys) :: rb1b
+  real (kind=kind_phys) :: stress1b 
+  
+  real (kind=kind_phys) :: wspdb
+  real (kind=kind_phys) :: flhcb
+  real (kind=kind_phys) :: flqcb
+!
 
   real (kind=kind_phys) :: taux       !wind stress: e-w (n/m2)
   real (kind=kind_phys) :: tauy       !wind stress: n-s (n/m2)
@@ -4449,6 +4597,15 @@ endif   ! croptype == 0
         cir = emg*sb
         cgh = 2.*df(isnow+1)/dzsnso(isnow+1)
 
+         gdx = sqrt(garea1)
+         snwd = snowh * 1000.0
+
+         if (snowh .gt. 0.1) then
+            mnice = 1
+         else
+            mnice = 0
+         endif
+
 ! -----------------------------------------------------------------
       loop3: do iter = 1, niterb  ! begin stability iteration
 
@@ -4492,14 +4649,47 @@ endif   ! croptype == 0
         if(opt_sfc == 3) then
           call sfcdif3(parameters,iloc    ,jloc    ,iter    ,sfctmp  ,qair    ,ur      , & !in 
                          zlvl    ,tgb     ,thsfc_loc,prslkix,prsik1x ,prslk1x ,z0m     , & !in 
-                         zpd  ,snowh,fveg ,garea1  ,.false. ,0.0,ivgtyp ,      & !in 
+                         zpd     ,snowh   ,shdfac  ,garea1  ,.false. ,0.0     ,ivgtyp  , & !in 
                          ustarx  ,fm      ,fh      ,fm2     ,fh2     ,                   & !inout 
                          z0h     ,fv      ,csigmaf0,cm      ,ch       )                    !out 
 
         endif
 
+        if(opt_sfc == 4) then
+
+          call sfcdif4(iloc  ,jloc  ,uu    ,vv    ,sfctmp , &
+                      sfcprs ,psfc  ,pblhx  ,gdx   ,z0m   , &
+                      itime  ,snwd  ,mnice     ,psi_opt   , &
+                      tgb   ,qair   ,zlvl  ,iz0tlnd,qsfc  , &
+                      h     ,qfx    ,cm    ,ch     ,ch2b ,  &
+                      cq2b  ,moz    ,fv    ,rb1b, fm, fh ,  &
+                     stress1b,fm10  ,fh2  , wspdb ,flhcb ,flqcb)
+
+        ! Undo the multiplication by windspeed that SFCDIF4
+          ! applies to exchange coefficients CH and CM:
+
+          ch   = ch / wspdb
+          cm   = cm / wspdb
+          ch2b = ch2b / wspdb
+          cq2b = cq2b / wspdb
+
+          if(snwd > 0.) then
+             cm = min(0.01,cm)
+             ch = min(0.01,ch)
+             ch2b = min(0.01,ch2b)
+             cq2b = min(0.01,cq2b)
+          end if
+
+         endif ! 4
+
         ramb = max(1.,1./(cm*ur))
         rahb = max(1.,1./(ch*ur))
+
+        if(opt_sfc == 4) then
+          ramb = max(1.,1./(cm*wspdb) )
+          rahb = max(1.,1./(ch*wspdb) )
+        endif
+
         rawb = rahb
 
 !jref - variables for diagnostics         
@@ -4581,6 +4771,13 @@ endif   ! croptype == 0
        ehb2  = fv*vkc/log((2.+z0h)/z0h)
        ehb2  = fv*vkc/(log((2.+z0h)/z0h)-fh2)
        cq2b  = ehb2
+      endif
+
+      if(opt_sfc == 4) then
+        ehb2 = 1. /(max(1.,1./ch2b*wspdb))
+        cq2b = 1. /(max(1.,1./cq2b*wspdb))
+      endif
+
        if (ehb2.lt.1.e-5 ) then
          t2mb  = tgb
          q2b   = qsfc
@@ -4589,7 +4786,6 @@ endif   ! croptype == 0
          q2b   = qsfc - evb/(lathea*rhoair)*(1./cq2b + rsurf)
        endif
        if (parameters%urban_flag) q2b = qsfc
-     end if
 
 ! update ch 
      ch = ehb
@@ -5095,7 +5291,7 @@ endif   ! croptype == 0
 !! compute surface drag coefficient cm for momentum and ch for heat.
   subroutine sfcdif3(parameters,iloc    ,jloc    ,iter    ,sfctmp  ,qair    ,ur      , & !in 
                        zlvl    ,tgb     ,thsfc_loc,prslkix,prsik1x ,prslk1x ,z0m     , & !in 
-                       zpd ,snowh ,fveg ,garea1 ,vegetated,vaie,vegtyp , & !in 
+                       zpd     ,snowh   ,fveg    ,garea1  ,vegetated,vaie   ,vegtyp  , & !in 
                        ustarx  ,fm      ,fh      ,fm2     ,fh2     ,                   & !inout 
                        z0h     ,fv      ,csigmaf ,cm      ,ch       )                    !out 
   
@@ -5151,28 +5347,12 @@ endif   ! croptype == 0
     real (kind=kind_phys) :: czil1                    ! canopy based czil
     real (kind=kind_phys) :: fm10                     ! 10-m stability adjustment - stability output
     real (kind=kind_phys) :: sigmaa                   ! momentum partition parameter
-    real (kind=kind_phys) :: tem1,tem2,zvfun1,gdx,slaifrac
+    real (kind=kind_phys) :: tem1,tem2,zvfun1,gdx
     real (kind=kind_phys), parameter :: z0lo=0.1, z0up=1.0
-    real (kind=kind_phys)  :: saimax !< monthly maximum stem area index, one-sided
-    real (kind=kind_phys)  :: laimax !< monthly maximum leaf area index, one-sided
 
 ! -------------------------------------------------------------------------------------------------
 
     fv        = ustarx
-    laimax = maxval(parameters%laim)
-    saimax = maxval(parameters%saim)
-    if(dveg.eq.4 .or. dveg.eq.5) then
-     if(laimax+saimax .gt. 0 .and. fveg .gt. 0) then
-      slaifrac=vaie/(laimax+saimax)
-      slaifrac=min(slaifrac,1.)
-      slaifrac=fveg*slaifrac
-      else
-      slaifrac=0.1_kind_phys
-     endif
-    else
-      slaifrac=fveg
-    endif
-
 !   fv        = ur*vkc/log((zlvl-zpd)/z0m)
 
     if(vegetated) then 
@@ -5223,7 +5403,7 @@ endif   ! croptype == 0
 
     tem1   = (z0m - z0lo) / (z0up - z0lo)
     tem1   = min(max(tem1, 0.0_kind_phys), 1.0_kind_phys)
-    tem2   = max(slaifrac, 0.1_kind_phys)
+    tem2   = max(fveg, 0.1_kind_phys)
     zvfun1 = sqrt(tem1 * tem2)
     gdx    = sqrt(garea1)
 
@@ -9757,5 +9937,1195 @@ end subroutine psn_crop
   
   end subroutine noahmp_options
 
+   subroutine sfcdif4(iloc  ,jloc  ,ux    ,vx     ,t1d  , &
+                      p1d   ,psfcpa,pblhx ,dx     ,znt  , &
+                      itime ,snwh ,isice  ,psi_opt,       &
+                      tsk   ,qx    ,zlvl  ,iz0tlnd,qsfc , &
+                      hfx   ,qfx   ,cm    ,chs    ,chs2 , &
+                      cqs2  ,                             &
+                      rmolx ,ust  , rbx, fmx, fhx,stressx,& 
+                      fm10x, fh2x, wspdx,flhcx,flqcx)
+
+
+
+!-------------------------------------------------------------------                                                      
+   implicit none                                                                                                          
+!-------------------------------------------------------------------                                                      
+                                                                                                                          
+! input                                                                                                                   
+
+   integer,intent(in )   :: iloc                                                                                          
+   integer,intent(in )   :: jloc                                                                                          
+   integer,  intent(in)  :: itime
+
+   integer,  intent(in)  :: psi_opt
+
+   integer,  intent(in)  :: isice     ! for the glacier/snowh > 0.1m
+                                                                                                                          
+   real,   intent(in )   :: pblhx      ! planetary boundary layer height                                                   
+   real,   intent(in )   :: tsk       ! skin temperature                                                                  
+   real,   intent(in )   :: psfcpa    ! pressure in pascal                                                                
+   real,   intent(in )   :: p1d       !lowest model layer pressure (pa)                                                      
+   real,   intent(in )   :: t1d       !lowest model layer temperature
+   real,   intent(in )   :: qx        !water vapor specific humidity (kg/kg) from input
+   real,   intent(in )   :: zlvl      ! thickness of lowest full level layer
+   real,   intent(in )   :: hfx       ! sensible heat flux
+   real,   intent(in )   :: qfx       ! moisture flux
+   real,   intent(in )   :: dx        ! horisontal grid spacing
+   real,   intent(in )   :: ux        ! u and v winds
+   real,   intent(in )   :: vx
+   real,   intent(in )   :: znt       ! z0m in m  or inout
+   real,   intent(in )   :: snwh     ! in mm                                                                                       
+
+! optional vars                                                                                                           
+
+   integer,optional,intent(in ) :: iz0tlnd                                                                                
+
+   real,   intent(inout) :: qsfc
+   real,   intent(inout) :: ust                                                                                           
+   real,   intent(inout) :: chs                                                                                           
+   real,   intent(inout) :: chs2                                                                                           
+   real,   intent(inout) :: cqs2                                                                                           
+   real,   intent(inout) :: cm                
+
+   real,   intent(inout) :: rmolx                                                                                          
+   real,   intent(inout) :: rbx
+   real,   intent(inout) :: fmx
+   real,   intent(inout) :: fhx
+   real,   intent(inout) :: stressx
+   real,   intent(inout) :: fm10x
+   real,   intent(inout) :: fh2x
+
+   real,   intent(inout) :: wspdx
+   real,   intent(inout) :: flhcx
+   real,   intent(inout) :: flqcx 
+
+   real                  :: zolx
+   real                  :: molx
+                                                                                                                          
+! diagnostics out                                                                                                         
+!  real,   intent(out)   :: u10                                                                                           
+!  real,   intent(out)   :: v10                                                                                           
+!   real,   intent(out)   :: th2                                                                                           
+!   real,   intent(out)   :: t2                                                                                            
+!   real,   intent(out)   :: q2                                                                                            
+!   real,   intent(out)   :: qsfc                                                                                          
+                                                                                                                          
+                                                                                                                          
+! local                                                                                                                   
+
+   real    :: za      ! height of full-sigma level                                                                        
+   real    :: thvx    ! virtual potential temperature                                                                     
+   real    :: zqkl    ! height of upper half level                                                                        
+   real    :: zqklp1  ! height of lower half level (surface)                                                              
+   real    :: thx     ! potential temperature                                                                             
+   real    :: psih    ! similarity function for heat                                                                      
+   real    :: psih2   ! similarity function for heat 2m                                                                   
+   real    :: psih10  ! similarity function for heat 10m                                                                  
+   real    :: psim    ! similarity function for momentum                                                                  
+   real    :: psim2   ! similarity function for momentum 2m                                                               
+   real    :: psim10  ! similarity function for momentum 10m                                                              
+
+   real    :: gz1oz0  ! log(za/z0)                                                                                        
+   real    :: gz2oz0  ! log(z2/z0)                                                                                        
+   real    :: gz10oz0 ! log(z10/z0)                                                                                       
+
+   real    :: rhox    ! density                                                                                           
+   real    :: govrth  ! g/theta for stability l                                                                           
+   real    :: tgdsa   ! tsk                                                                                               
+   real    :: tvir    ! temporal variable src4 -> tvir                                                                                
+   real    :: thgb    ! potential temperature ground                                                                      
+   real    :: psfcx   ! surface pressure                                                                                  
+   real    :: cpm                                                                                           
+   real    :: qgh    
+                                                                                                                          
+   integer :: n,i,k,kk,l,nzol,nk,nzol2,nzol10                                                                             
+
+   real    :: zolzt, zolz0, zolza
+   real    :: gz1ozt,gz2ozt,gz10ozt
+
+                                                                                                                          
+   real    ::  pl,thcon,tvcon,e1                                                                                          
+   real    ::  zl,tskv,dthvdz,dthvm,vconv,rzol,rzol2,rzol10,zol2,zol10                                                    
+   real    ::  dtg,psix,dtthx,psix10,psit,psit2,psiq,psiq2,psiq10                                                         
+   real    ::  fluxc,vsgd,z0q,visc,restar,czil,restar2                                                                    
+
+   real    ::  dqg
+   real    ::  tabs
+   real    ::  qsfcmr
+   real    ::  t1dc
+   real    ::  zt
+   real    ::  zq
+   real    ::  zratio
+   real    ::  qstar
+!-------------------------------------------------------------------                                                      
+
+   psfcx=psfcpa/1000.     ! to kPa for saturation check                                                                                                 
+                                                                                                                          
+         if (itime == 1) then                               !init SP, MR
+           if (isice == 0) then
+                 tabs = 0.5*(tsk + t1d)
+               if (tabs .lt. 273.15) then
+                  !saturation vapor pressure wrt ice (svp1=.6112; 10*mb)
+                  e1=svp1*exp(4648*(1./273.15 - 1./tabs) - &
+                    & 11.64*log(273.15/tabs) + 0.02265*(273.15 - tabs))
+               else
+                  !saturation vapor pressure wrt water (bolton 1980)
+                  e1=svp1*exp(svp2*(tabs-svpt0)/(tabs-svp3))
+               endif
+
+               qsfc    =ep2*e1/(psfcx-ep_3*e1)               !avg with the input?
+               qsfcmr  =qsfc/(1.-qsfc)                      !to mixing ratio
+            endif
+
+           if (isice == 1) then
+               if (tsk .lt. 273.15) then
+                                 !saturation vapor pressure wrt ice (svp1=.6112; 10*mb)
+                   e1=svp1*exp(4648*(1./273.15 - 1./tsk) - &
+                    & 11.64*log(273.15/tsk) + 0.02265*(273.15 - tsk))
+               else
+                  !saturation vapor pressure wrt water (bolton 1980)
+                  e1=svp1*exp(svp2*(tsk-svpt0)/(tsk-svp3))
+               endif
+
+               qsfc=ep2*e1/(psfcx-ep_3*e1)             !specific humidity
+               qsfcmr=ep2*e1/(psfcx-e1)                !mixing ratio
+
+            endif
+
+         else
+            ! use what comes out of the lsm
+            if (isice == 0) then
+                 tabs = 0.5*(tsk + t1d)
+               if (tabs .lt. 273.15) then
+                  !saturation vapor pressure wrt ice (svp1=.6112; 10*mb)
+                  e1=svp1*exp(4648*(1./273.15 - 1./tabs) - &
+                    & 11.64*log(273.15/tabs) + 0.02265*(273.15 - tabs))
+               else
+                  !saturation vapor pressure wrt water (bolton 1980)
+                  e1=svp1*exp(svp2*(tabs-svpt0)/(tabs-svp3))
+               endif
+             
+               qsfc    =ep2*e1/(psfcx-ep_3*e1)        ! avg with previous qsfc? 
+               qsfcmr=qsfc/(1.-qsfc)
+
+             endif
+
+           if (isice == 1) then
+               if (tsk .lt. 273.15) then
+                                 !saturation vapor pressure wrt ice (svp1=.6112; 10*mb)
+                   e1=svp1*exp(4648*(1./273.15 - 1./tsk) - &
+                    & 11.64*log(273.15/tsk) + 0.02265*(273.15 - tsk))
+               else
+                  !saturation vapor pressure wrt water (bolton 1980)
+                  e1=svp1*exp(svp2*(tsk-svpt0)/(tsk-svp3))
+               endif
+
+               qsfc=ep2*e1/(psfcx-ep_3*e1)             !specific humidity
+               qsfcmr=qsfc/(1.-qsfc)
+
+               endif
+
+         endif                                     !done INIT if itime=1
+! convert (tah or tgb = tsk) temperature to potential temperature.                                                                    
+   tgdsa = tsk              
+   thgb  = tsk*(p1000mb/psfcpa)**rcp  !psfcpa is pa
+                                   
+! store virtual, virtual potential and potential temperature
+
+   pl    = p1d/1000.                                                                                                      
+   thx   = t1d*(p1000mb*0.001/pl)**rcp                                                                                        
+   t1dc  = t1d - 273.15
+
+   thvx  = thx*(1.+ep_1*qx)           !qx is SH from input     
+   tvir  = t1d*(1.+ep_1*qx)
+
+   rhox=psfcx*1000./(r_d*tvir)                                                                                             
+   govrth=g/thx                                                                                                           
+   za = zlvl
+   
+   !za=0.5*dz8w                                                                                                   
+
+
+!   directly from input; check units
+
+!   qfx = qflx * rhox
+!   hfx = hflx * rhox * cp
+
+
+
+! q2sat = qgh in lsm                                                                                                      
+!jref: canres and esat is calculated in the loop so should that be changed??
+!   qgh=ep_2*e1/(pl-e1)                                                                                                    
+!   cpm=cp*(1.+0.8*qx)                                                                                                     
+
+
+! qgh changed to use lowest-level air temp 
+
+         if (t1d .lt. 273.15) then
+            !saturation vapor pressure wrt ice
+            e1=svp1*exp(4648.*(1./273.15 - 1./t1d) - &
+            &  11.64*log(273.15/t1d) + 0.02265*(273.15 - t1d))
+         else
+            !saturation vapor pressure wrt water (bolton 1980)
+            e1=svp1*exp(svp2*(t1d-svpt0)/(t1d-svp3))
+         endif
+
+
+         !qgh=ep2*e1/(pl-ep_3*e1)    !specific humidity
+
+         qgh=ep2*e1/(pl-e1)          !sat. mixing ratio ?
+
+!        cpm=cp*(1.+0.84*qx)         ! qx is SH
+         cpm=cp*(1.+0.84*qx/(1.0-qx) )
+
+         wspdx=sqrt(ux*ux+vx*vx)                                                                                                 
+
+         tskv=thgb*(1.+ep_1*qsfc)  !avg with tsurf not used                                                                                             
+         dthvdz=(thvx-tskv)                                                                                                     
+
+         fluxc = max(hfx/rhox/cp + ep_1*tskv*qfx/rhox,0.)   !hfx + qfx are fluxes units: wm^-2 and kg m^-2 s^-1                                                                                       
+! vconv = vconvc*(g/tgdsa*pblh*fluxc)**.33                                                                                
+
+          vconv = vconvc*(g/tgdsa*min(1.5*pblhx,4000.0)*fluxc)**.33   !wstar                                                                             
+!  vsgd = 0.32 * (max(dx/5000.-1.,0.))**.33                                                                               
+
+          vsgd = min(0.32 * (max(dx/5000.-1.,0.))**.33,0.5)                                                                               
+          wspdx=sqrt(wspdx*wspdx+vconv*vconv+vsgd*vsgd)                                                                             
+          wspdx=max(wspdx,0.1)                              !0.1 is wmin                                                                       
+          rbx=govrth*za*dthvdz/(wspdx*wspdx)                !buld rich #                                                                         
+
+          if (itime == 1) then
+                rbx=max(rbx,-2.0)
+                rbx=min(rbx, 2.0)
+           else
+                rbx=max(rbx,-4.0)
+                rbx=min(rbx, 4.0)
+           endif
+
+
+!        visc=(1.32+0.009*(t1d-273.15))*1.e-5                                                                            
+! kinematic viscosity
+
+
+         visc=1.326e-5*(1. + 6.542e-3*t1dc + 8.301e-6*t1dc*t1dc &
+                      - 4.84e-9*t1dc*t1dc*t1dc)
+
+!compute roughness reynolds number (restar) using default znt
+!the GFS option has been removed
+
+         restar=max(ust*znt/visc,0.1)                                                                                               
+
+! get zt, zq based on the input
+! the GFS roughness option and spp_pbl have been removed
+
+       if (snwh > 50. .or. isice == 1) then  ! (mm) treat as snow cover - use andreas cover isice =1
+          call andreas_2002(znt,visc,ust,zt,zq)
+       else
+          if ( present(iz0tlnd) ) then
+             if ( iz0tlnd .le. 1 ) then
+                call zilitinkevich_1995(znt,zt,zq,restar,&
+                      ust,karman,1.0,iz0tlnd,0,0.0)
+             elseif ( iz0tlnd .eq. 2 ) then
+                call yang_2008(znt,zt,zq,ust,molx,&
+                              qstar,restar,visc)
+             elseif ( iz0tlnd .eq. 3 ) then
+                !original mynn in wrf-arw used this form:
+                call garratt_1992(zt,zq,znt,restar,1.0)
+             endif
+
+! the GFS option is removed along with gfs_z0_lnd
+
+          else
+
+             !default to zilitinkevich
+             call zilitinkevich_1995(znt,zt,zq,restar,&
+                         ust,karman,1.0,0,0,0.0)
+          endif
+       endif
+
+
+! --------- 
+! calculate bulk richardson no. of surface layer,                                                                         
+! according to akb(1976), eq(12).                                                                                         
+
+       gz1oz0= log((za+znt)/znt)
+       gz1ozt= log((za+znt)/zt)
+       gz2oz0= log((2.0+znt)/znt)
+       gz2ozt= log((2.0+znt)/zt)
+       gz10oz0=log((10.+znt)/znt)
+!      gz10ozt=log((10.+znt)/zt)
+
+       zratio=znt/zt   !need estimate for li et al.
+
+
+! vconv = 0.25*sqrt(g/tskv*pblh(i)*dthvm)                                                                                 
+!  if(mol.lt.0.) br=amin1(br,0.0)   -> check the input mol later
+!  rmol=-govrth*dthvdz*za*karman 
+
+       if (rbx .gt. 0.0) then
+
+          !compute z/l first guess:
+          call li_etal_2010(zolx,rbx,za/znt,zratio)
+          !zol=za*karman*g*mol/(thx*max(ust*ust,0.0001))
+          zolx=max(zolx,0.0)
+          zolx=min(zolx,20.)
+
+
+          !use pedros iterative function to find z/l
+          !zol=zolri(rb_lnd,za,zntstoch_lnd,zt_lnd,zol,psi_opt)
+          !use brute-force method
+
+          zolx=zolrib(rbx,za,znt,zt,gz1oz0,gz1ozt,zolx,psi_opt)
+          zolx=max(zolx,0.0)
+          zolx=min(zolx,20.)
+
+          zolzt = zolx*zt/za           ! zt/l
+          zolz0 = zolx*znt/za          ! z0/l
+          zolza = zolx*(za+znt)/za     ! (z+z0/l
+          zol10 = zolx*(10.+znt)/za    ! (10+z0)/l
+          zol2  = zolx*(2.+znt)/za     ! (2+z0)/l 
+
+          !compute psim and psih
+          !call psi_beljaars_holtslag_1991(psim,psih,zol)
+          !call psi_businger_1971(psim,psih,zol)
+          !call psi_zilitinkevich_esau_2007(psim,psih,zol)
+          !call psi_dyerhicks(psim,psih,zol,zt_lnd,zntstoch_lnd,za)
+          !call psi_cb2005(psim,psih,zolza,zolz0)
+
+          psim=psim_stable(zolza,psi_opt)-psim_stable(zolz0,psi_opt)
+          psih=psih_stable(zolza,psi_opt)-psih_stable(zolzt,psi_opt)
+          psim10=psim_stable(zol10,psi_opt)-psim_stable(zolz0,psi_opt)
+!         psih10=psih_stable(zol10,psi_opt)-psih_stable(zolz0,psi_opt)
+          psih2=psih_stable(zol2,psi_opt)-psih_stable(zolzt,psi_opt)
+
+          ! 1.0 over monin-obukhov length
+
+          rmolx= zolx/za
+
+       elseif(rbx .eq. 0.) then                  
+          !=========================================================  
+          !-----class 3; forced convection/neutral:                                                
+          !=========================================================
+
+          psim=0.0
+          psih=psim
+          psim10=0.
+!         psih10=0.
+          psih2=0.
+
+          zolx  =0.
+          rmolx =0.
+
+       elseif(rbx .lt. 0.)then
+          !==========================================================
+          !-----class 4; free convection:                                                  
+          !==========================================================
+
+          !compute z/l first guess:
+
+          call li_etal_2010(zolx,rbx,za/znt,zratio)
+
+          !zol=za*karman*g*mol/(th1d*max(ust_lnd*ust_lnd,0.001))
+
+          zolx=max(zolx,-20.0)
+          zolx=min(zolx,0.0)
+
+
+          !use pedros iterative function to find z/l
+          !zol=zolri(rb_lnd,za,zntstoch_lnd,zt_lnd,zol,psi_opt)
+          !use brute-force method
+
+          zolx=zolrib(rbx,za,znt,zt,gz1oz0,gz1ozt,zolx,psi_opt)
+          zolx=max(zolx,-20.0)
+          zolx=min(zolx,0.0)
+
+          zolzt = zolx*zt/za            ! zt/l
+          zolz0 = zolx*znt/za           ! z0/l
+          zolza = zolx*(za+znt)/za      ! (z+z0/l
+          zol10 = zolx*(10.+znt)/za     ! (10+z0)/l
+          zol2  = zolx*(2.+znt)/za      ! (2+z0)/l
+
+          !compute psim and psih
+          !call psi_hogstrom_1996(psim,psih,zol, zt_lnd, zntstoch_lnd, za)
+          !call psi_businger_1971(psim,psih,zol)
+          !call psi_dyerhicks(psim,psih,zol,zt_lnd,zntstoch_lnd,za)
+          ! use tables
+
+          psim=psim_unstable(zolza,psi_opt)-psim_unstable(zolz0,psi_opt)
+          psih=psih_unstable(zolza,psi_opt)-psih_unstable(zolzt,psi_opt)
+          psim10=psim_unstable(zol10,psi_opt)-psim_unstable(zolz0,psi_opt)
+!         psih10=psih_unstable(zol10,psi_opt)-psih_unstable(zolz0,psi_opt)
+          psih2=psih_unstable(zol2,psi_opt)-psih_unstable(zolzt,psi_opt)
+
+          !---limit psih and psim in the case of thin layers and
+          !---high roughness.  this prevents denominator in fluxes
+          !---from getting too small
+
+          psih=min(psih,0.9*gz1ozt)
+          psim=min(psim,0.9*gz1oz0)
+          psih2=min(psih2,0.9*gz2ozt)
+          psim10=min(psim10,0.9*gz10oz0)
+!         psih10=min(psih10,0.9*gz10ozt)
+
+          rmolx = zolx/za  
+
+       endif
+
+       ! calculate the resistance:
+
+       psix  =max(gz1oz0-psim, 1.0)
+       psix10=max(gz10oz0-psim10, 1.0)
+       psit  =max(gz1ozt-psih , 1.0)
+       psit2 =max(gz2ozt-psih2, 1.0)
+       psiq  =max(log((za+zq)/zq)-psih ,1.0)
+       psiq2 =max(log((2.0+zq)/zq)-psih2 ,1.0)
+
+    !------------------------------------------------------------
+    !-----compute the frictional velocity:                                           
+    !------------------------------------------------------------
+
+
+       ! to prevent oscillations average with old value
+
+!      oldust = ust
+
+       ust=0.5*ust+0.5*karman*wspdx/psix
+       ust=max(ust,0.005)
+
+!      stress=ust**2
+
+       !set ustm = ust over land.
+
+!      ustmx=ust
+
+
+    !----------------------------------------------------
+    !----compute the temperature scale (a.k.a. friction temperature, t*, or mol)
+    !----and compute the moisture scale (or q*)
+    !----------------------------------------------------
+
+       dtg=thvx-tskv
+
+!      oldtst=mol
+
+       molx=karman*dtg/psit/prt !T*
+
+       !t_star = -hfx/(ust*cpm*rho1d)
+       !t_star = mol
+       !----------------------------------------------------
+       ! dqg=(qvsh-qsfc)*1000.   !(kg/kg -> g/kg)
+
+       dqg=(qx-qsfc)*1000.   !(kg/kg -> g/kg)
+       qstar=karman*dqg/psiq/prt
+
+        cm = (karman/psix)*(karman/psix)*wspdx
+
+!       cm = (karman/psix)*(karman/psix)
+!       ch = (karman/psix)*(karman/psit)
+
+        chs=ust*karman/psit
+        cqs2=ust*karman/psiq2
+        chs2=ust*karman/psit2
+
+!       u10=ux*psix10/psix                                                                                                     
+!       v10=vx*psix10/psix                                                                                                     
+
+        flhcx = rhox*cpm*ust*karman/psit
+        flqcx = rhox*1.0*ust*karman/psiq
+
+!       ch = flhcx/(cpm*rhox)  !same chs
+
+        fmx = psix
+        fhx = psit
+        fm10x = psix10
+        fh2x =psit2
+
+!       ustmx = ust
+
+        stressx = ust**2 ! or cm*wind*wind
+
+   end subroutine sfcdif4                                                                                                 
+
+  subroutine zilitinkevich_1995(z_0,zt,zq,restar,ustar,karman,&
+        & landsea,iz0tlnd2,spp_pbl,rstoch)
+
+       implicit none
+       real, intent(in) :: z_0,restar,ustar,karman,landsea
+       integer, optional, intent(in)::  iz0tlnd2
+       real, intent(out) :: zt,zq
+       real :: czil  !=0.100 in chen et al. (1997)
+                     !=0.075 in zilitinkevich (1995)
+                     !=0.500 in lemone et al. (2008)
+       integer,  intent(in)  ::    spp_pbl
+       real,     intent(in)  ::    rstoch
+
+
+       if (landsea-1.5 .gt. 0) then    !water
+
+          !this is based on zilitinkevich, grachev, and fairall (2001;
+          !their equations 15 and 16).
+          if (restar .lt. 0.1) then
+             zt = z_0*exp(karman*2.0)
+             zt = min( zt, 6.0e-5)
+             zt = max( zt, 2.0e-9)
+             zq = z_0*exp(karman*3.0)
+             zq = min( zq, 6.0e-5)
+             zq = max( zq, 2.0e-9)
+          else
+             zt = z_0*exp(-karman*(4.0*sqrt(restar)-3.2))
+             zt = min( zt, 6.0e-5)
+             zt = max( zt, 2.0e-9)
+             zq = z_0*exp(-karman*(4.0*sqrt(restar)-4.2))
+             zq = min( zt, 6.0e-5)
+             zq = max( zt, 2.0e-9)
+          endif
+
+       else                             !land
+
+          !option to modify czil according to chen & zhang, 2009
+          if ( iz0tlnd2 .eq. 1 ) then
+             czil = 10.0 ** ( -0.40 * ( z_0 / 0.07 ) )
+          else
+             czil = 0.085 !0.075 !0.10
+          end if
+
+          zt = z_0*exp(-karman*czil*sqrt(restar))
+          zt = min( zt, 0.75*z_0)
+
+          zq = z_0*exp(-karman*czil*sqrt(restar))
+          zq = min( zq, 0.75*z_0)
+
+! stochastically perturb thermal and moisture roughness length.
+! currently set to half the amplitude: 
+          if (spp_pbl==1) then
+             zt = zt + zt * 0.5 * rstoch
+             zt = max(zt, 0.0001)
+             zq = zt
+          endif
+
+       endif
+                   
+       return
+
+   end subroutine zilitinkevich_1995
+
+!!data. the formula for land uses a constant ratio (z_0/7.4) taken
+!!from garratt (1992).
+   subroutine garratt_1992(zt,zq,z_0,ren,landsea)
+
+       implicit none
+       real, intent(in)  :: ren, z_0,landsea
+       real, intent(out) :: zt,zq
+       real :: rq
+       real, parameter  :: e=2.71828183
+
+       if (landsea-1.5 .gt. 0) then    !water
+
+          zt = z_0*exp(2.0 - (2.48*(ren**0.25)))
+          zq = z_0*exp(2.0 - (2.28*(ren**0.25)))
+
+          zq = min( zq, 5.5e-5)
+          zq = max( zq, 2.0e-9)
+          zt = min( zt, 5.5e-5)
+          zt = max( zt, 2.0e-9) !same lower limit as ecmwf
+       else                            !land
+          zq = z_0/(e**2.)      !taken from garratt (1980,1992)
+          zt = zq
+       endif
+                   
+       return
+
+    end subroutine garratt_1992
+!--------------------------------------------------------------------
+!>\ingroup mynn_sfc
+!> this is a modified version of yang et al (2002 qjrms, 2008 jamc) 
+!! and chen et al (2010, j of hydromet). although it was originally 
+!! designed for arid regions with bare soil, it is modified 
+!! here to perform over a broader spectrum of vegetation.
+!!
+!!the original formulation relates the thermal roughness length (zt) 
+!!to u* and t*:
+!!  
+!! zt = ht * exp(-beta*(ustar**0.5)*(abs(tstar)**0.25))
+!!
+!!where ht = renc*visc/ustar and the critical reynolds number 
+!!(renc) = 70. beta was originally = 10 (2002 paper) but was revised 
+!!to 7.2 (in 2008 paper). their form typically varies the
+!!ratio z0/zt by a few orders of magnitude (1-1e4).
+!!
+!!this modified form uses beta = 1.5 and a variable renc (function of z_0),
+!!so zt generally varies similarly to the zilitinkevich form (with czil = 0.1)
+!!for very small or negative surface heat fluxes but can become close to the
+!!zilitinkevich with czil = 0.2 for very large hfx (large negative t*).
+!!also, the exponent (0.25) on tstar was changed to 1.0, since we found
+!!zt was reduced too much for low-moderate positive heat fluxes.
+!!
+!!this should only be used over land!
+       subroutine yang_2008(z_0,zt,zq,ustar,tstar,qst,ren,visc)
+
+       implicit none
+       real, intent(in)  :: z_0, ren, ustar, tstar, qst, visc
+       real              :: ht,     &! roughness height at critical reynolds number
+                            tstar2, &! bounded t*, forced to be non-positive
+                            qstar2, &! bounded q*, forced to be non-positive
+                            z_02,   &! bounded z_0 for variable renc2 calc
+                            renc2    ! variable renc, function of z_0
+       real, intent(out) :: zt,zq
+       real, parameter  :: renc=300., & !old constant renc
+                           beta=1.5,  & !important for diurnal variation
+                           m=170.,    & !slope for renc2 function
+                           b=691.       !y-intercept for renc2 function
+
+       z_02 = min(z_0,0.5)
+       z_02 = max(z_02,0.04)
+       renc2= b + m*log(z_02)
+       ht     = renc2*visc/max(ustar,0.01)
+       tstar2 = min(tstar, 0.0)
+       qstar2 = min(qst,0.0)
+
+       zt     = ht * exp(-beta*(ustar**0.5)*(abs(tstar2)**1.0))
+       zq     = ht * exp(-beta*(ustar**0.5)*(abs(qstar2)**1.0))
+       !zq     = zt
+
+       zt = min(zt, z_0/2.0)
+       zq = min(zq, z_0/2.0)
+
+       return
+
+    end subroutine yang_2008
+
+!>\ingroup mynn_sfc
+!> this is taken from andreas (2002; j. of hydromet) and 
+!! andreas et al. (2005; blm).
+!!
+!! this should only be used over snow/ice!
+    subroutine andreas_2002(z_0,bvisc,ustar,zt,zq)
+
+       implicit none
+       real, intent(in)  :: z_0, bvisc, ustar
+       real, intent(out) :: zt, zq
+       real :: ren2, zntsno
+
+       real, parameter  :: bt0_s=1.25,  bt0_t=0.149,  bt0_r=0.317,  &
+                           bt1_s=0.0,   bt1_t=-0.55,  bt1_r=-0.565, &
+                           bt2_s=0.0,   bt2_t=0.0,    bt2_r=-0.183
+
+       real, parameter  :: bq0_s=1.61,  bq0_t=0.351,  bq0_r=0.396,  &
+                           bq1_s=0.0,   bq1_t=-0.628, bq1_r=-0.512, &
+                           bq2_s=0.0,   bq2_t=0.0,    bq2_r=-0.180
+
+      !calculate zo for snow (andreas et al. 2005, blm)                                                                     
+       zntsno = 0.135*bvisc/ustar + &
+               (0.035*(ustar*ustar)/9.8) * &
+               (5.*exp(-1.*(((ustar - 0.18)/0.1)*((ustar - 0.18)/0.1))) + 1.)                                                
+       ren2 = ustar*zntsno/bvisc
+
+       ! make sure that re is not outside of the range of validity
+       ! for using their equations
+       if (ren2 .gt. 1000.) ren2 = 1000. 
+
+       if (ren2 .le. 0.135) then
+
+          zt = zntsno*exp(bt0_s + bt1_s*log(ren2) + bt2_s*log(ren2)**2)
+          zq = zntsno*exp(bq0_s + bq1_s*log(ren2) + bq2_s*log(ren2)**2)
+
+       else if (ren2 .gt. 0.135 .and. ren2 .lt. 2.5) then
+
+          zt = zntsno*exp(bt0_t + bt1_t*log(ren2) + bt2_t*log(ren2)**2)
+          zq = zntsno*exp(bq0_t + bq1_t*log(ren2) + bq2_t*log(ren2)**2)
+
+       else
+
+          zt = zntsno*exp(bt0_r + bt1_r*log(ren2) + bt2_r*log(ren2)**2)
+          zq = zntsno*exp(bq0_r + bq1_r*log(ren2) + bq2_r*log(ren2)**2)
+
+       endif
+
+       return
+
+    end subroutine andreas_2002
+!--------------------------------------------------------------------
+!>\ingroup mynn_sfc
+!! this subroutine returns a more robust z/l that best matches
+!! the z/l from hogstrom (1996) for unstable conditions and beljaars
+!! and holtslag (1991) for stable conditions.
+    subroutine li_etal_2010(zl, rib, zaz0, z0zt)
+
+       implicit none
+       real, intent(out)  :: zl
+       real, intent(in) :: rib, zaz0, z0zt
+       real :: alfa, beta, zaz02, z0zt2
+       real, parameter  :: au11=0.045, bu11=0.003, bu12=0.0059, &
+                          &bu21=-0.0828, bu22=0.8845, bu31=0.1739, &
+                          &bu32=-0.9213, bu33=-0.1057
+       real, parameter  :: aw11=0.5738, aw12=-0.4399, aw21=-4.901,&
+                          &aw22=52.50, bw11=-0.0539, bw12=1.540, &
+                          &bw21=-0.669, bw22=-3.282
+       real, parameter  :: as11=0.7529, as21=14.94, bs11=0.1569,&
+                          &bs21=-0.3091, bs22=-1.303
+          
+       !set limits according to li et al (2010), p 157.
+       zaz02=zaz0
+       if (zaz0 .lt. 100.0) zaz02=100.
+       if (zaz0 .gt. 100000.0) zaz02=100000.
+
+       !set more limits according to li et al (2010)
+       z0zt2=z0zt
+       if (z0zt .lt. 0.5) z0zt2=0.5
+       if (z0zt .gt. 100.0) z0zt2=100.
+
+       alfa = log(zaz02)
+       beta = log(z0zt2)
+
+       if (rib .le. 0.0) then
+          zl = au11*alfa*rib**2 + (                   &
+               &  (bu11*beta + bu12)*alfa**2 +        &
+               &  (bu21*beta + bu22)*alfa    +        &
+               &  (bu31*beta**2 + bu32*beta + bu33))*rib
+          !if(zl .lt. -15 .or. zl .gt. 0.)print*,"violation rib<0:",zl
+          zl = max(zl,-15.) !limits set according to li et al (2010)
+          zl = min(zl,0.)   !figure 1.
+       elseif (rib .gt. 0.0 .and. rib .le. 0.2) then
+          zl = ((aw11*beta + aw12)*alfa +             &
+             &  (aw21*beta + aw22))*rib**2 +          &
+             & ((bw11*beta + bw12)*alfa +             &
+             &  (bw21*beta + bw22))*rib
+          !if(zl .lt. 0 .or. zl .gt. 4)print*,"violation 0<rib<0.2:",zl
+          zl = min(zl,4.) !limits approx set according to li et al (2010)
+          zl = max(zl,0.) !their figure 1b.
+       else
+          zl = (as11*alfa + as21)*rib + bs11*alfa +   &
+             &  bs21*beta + bs22
+          !if(zl .le. 1 .or. zl .gt. 23)print*,"violation rib>0.2:",zl
+          zl = min(zl,20.) !limits according to li et al (2010), thier
+                           !figue 1c.
+          zl = max(zl,1.)
+       endif
+
+       return
+
+    end subroutine li_etal_2010
+!-------------------------------------------------------------------
+      real function zolri(ri,za,z0,zt,zol1,psi_opt)
+
+      ! this iterative algorithm was taken from the revised surface layer 
+      ! scheme in wrf-arw, written by pedro jimenez and jimy dudhia and 
+      ! summarized in jimenez et al. (2012, mwr). this function was adapted
+      ! to input the thermal roughness length, zt, (as well as z0) and use initial
+      ! estimate of z/l.
+
+      implicit none
+      real, intent(in) :: ri,za,z0,zt,zol1
+      integer, intent(in) :: psi_opt
+      real :: x1,x2,fx1,fx2
+      integer :: n
+      integer, parameter :: nmax = 20
+      !real, dimension(nmax):: zlhux
+!     real  :: zolri2
+
+      if (ri.lt.0.)then
+         x1=zol1 - 0.02  !-5.
+         x2=0.
+      else
+         x1=0.
+         x2=zol1 + 0.02 !5.
+      endif
+
+      n=1
+      fx1=zolri2(x1,ri,za,z0,zt,psi_opt)
+      fx2=zolri2(x2,ri,za,z0,zt,psi_opt)
+
+      do while (abs(x1 - x2) > 0.01 .and. n < nmax)
+        if(abs(fx2).lt.abs(fx1))then
+          x1=x1-fx1/(fx2-fx1)*(x2-x1)
+          fx1=zolri2(x1,ri,za,z0,zt,psi_opt)
+          zolri=x1
+        else
+          x2=x2-fx2/(fx2-fx1)*(x2-x1)
+          fx2=zolri2(x2,ri,za,z0,zt,psi_opt)
+          zolri=x2
+        endif
+        n=n+1
+        !print*," n=",n," x1=",x1," x2=",x2
+        !zlhux(n)=zolri
+      enddo
+
+      if (n==nmax .and. abs(x1 - x2) >= 0.01) then
+         !if convergence fails, use approximate values:
+         call li_etal_2010(zolri, ri, za/z0, z0/zt)
+         !zlhux(n)=zolri
+         !print*,"iter fail, n=",n," ri=",ri," z0=",z0
+      else
+         !print*,"success,n=",n," ri=",ri," z0=",z0
+      endif
+
+      return
+      end function
+!-------------------------------------------------------------------
+      real function zolri2(zol2,ri2,za,z0,zt,psi_opt)
+
+      ! input: =================================
+      ! zol2 - estimated z/l
+      ! ri2  - calculated bulk richardson number
+      ! za   - 1/2 depth of first model layer
+      ! z0   - aerodynamic roughness length
+      ! zt   - thermal roughness length
+      ! output: ================================
+      ! zolri2 - delta ri
+
+      implicit none
+      integer, intent(in) :: psi_opt
+      real, intent(in) :: ri2,za,z0,zt
+      real, intent(inout) :: zol2
+      real :: zol20,zol3,psim1,psih1,psix2,psit2,zolt
+
+!     real :: psih_unstable,psim_unstable,psih_stable, psim_stable
+
+      if(zol2*ri2 .lt. 0.)zol2=0.  ! limit zol2 - must be same sign as ri2
+
+      zol20=zol2*z0/za ! z0/l
+      zol3=zol2+zol20  ! (z+z0)/l
+      zolt=zol2*zt/za  ! zt/l
+
+      if (ri2.lt.0) then
+         !psix2=log((za+z0)/z0)-(psim_unstable(zol3)-psim_unstable(zol20))
+         !psit2=log((za+zt)/zt)-(psih_unstable(zol3)-psih_unstable(zol20))
+         psit2=max(log((za+z0)/zt)-(psih_unstable(zol3,psi_opt)-psih_unstable(zolt,psi_opt)), 1.0)
+         psix2=max(log((za+z0)/z0)-(psim_unstable(zol3,psi_opt)-psim_unstable(zol20,psi_opt)),1.0)
+      else
+         !psix2=log((za+z0)/z0)-(psim_stable(zol3)-psim_stable(zol20))
+         !psit2=log((za+zt)/zt)-(psih_stable(zol3)-psih_stable(zol20))
+         psit2=max(log((za+z0)/zt)-(psih_stable(zol3,psi_opt)-psih_stable(zolt,psi_opt)), 1.0)
+         psix2=max(log((za+z0)/z0)-(psim_stable(zol3,psi_opt)-psim_stable(zol20,psi_opt)),1.0)
+      endif
+
+      zolri2=zol2*psit2/psix2**2 - ri2
+      !print*,"  target ri=",ri2," est ri=",zol2*psit2/psix2**2
+
+      return
+      end function
+!====================================================================
+
+      real function zolrib(ri,za,z0,zt,logz0,logzt,zol1,psi_opt)
+
+      ! this iterative algorithm to compute z/l from bulk-ri
+
+      implicit none
+      real, intent(in) :: ri,za,z0,zt,logz0,logzt
+      integer, intent(in) :: psi_opt
+      real, intent(inout) :: zol1
+      real :: zol20,zol3,zolt,zolold
+      integer :: n
+      integer, parameter :: nmax = 20
+      real, dimension(nmax):: zlhux
+      real :: psit2,psix2
+
+!     real    :: psim_unstable, psim_stable
+!     real    :: psih_unstable, psih_stable
+
+      !print*,"+++++++incoming: z/l=",zol1," ri=",ri
+      if (zol1*ri .lt. 0.) then
+         !print*,"begin: wrong quadrants: z/l=",zol1," ri=",ri
+         zol1=0.
+      endif
+
+      if (ri .lt. 0.) then
+        zolold=-99999.
+        zolrib=-66666.
+      else
+        zolold=99999.
+        zolrib=66666.
+      endif
+      n=1
+
+      do while (abs(zolold - zolrib) > 0.01 .and. n < nmax)
+
+        if(n==1)then
+          zolold=zol1
+        else
+          zolold=zolrib
+        endif
+        zol20=zolold*z0/za ! z0/l
+        zol3=zolold+zol20  ! (z+z0)/l
+        zolt=zolold*zt/za  ! zt/l
+        !print*,"z0/l=",zol20," (z+z0)/l=",zol3," zt/l=",zolt
+        if (ri.lt.0) then
+           !psit2=log((za+zt)/zt)-(psih_unstable(zol3)-psih_unstable(zol20))
+           !psit2=log((za+z0)/zt)-(psih_unstable(zol3)-psih_unstable(zol20))
+           psit2=max(logzt-(psih_unstable(zol3,psi_opt)-psih_unstable(zolt,psi_opt)), 1.0)
+           psix2=max(logz0-(psim_unstable(zol3,psi_opt)-psim_unstable(zol20,psi_opt)), 1.0)
+        else
+           !psit2=log((za+zt)/zt)-(psih_stable(zol3)-psih_stable(zol20))
+           !psit2=log((za+z0)/zt)-(psih_stable(zol3)-psih_stable(zol20))
+           psit2=max(logzt-(psih_stable(zol3,psi_opt)-psih_stable(zolt,psi_opt)), 1.0)
+           psix2=max(logz0-(psim_stable(zol3,psi_opt)-psim_stable(zol20,psi_opt)), 1.0)
+        endif
+        !print*,"n=",n," psit2=",psit2," psix2=",psix2
+        zolrib=ri*psix2**2/psit2
+        zlhux(n)=zolrib
+        n=n+1
+      enddo
+
+      if (n==nmax .and. abs(zolold - zolrib) > 0.01 ) then
+         !print*,"iter fail, n=",n," ri=",ri," z/l=",zolri
+         !if convergence fails, use approximate values:
+         call li_etal_2010(zolrib, ri, za/z0, z0/zt)
+         zlhux(n)=zolrib
+         !print*,"failed, n=",n," ri=",ri," z0=",z0
+         !print*,"z/l=",zlhux(1:nmax)
+      else
+         !if(zolrib*ri .lt. 0.) then
+         !   !print*,"end: wrong quadrants: z/l=",zolrib," ri=",ri
+         !   !call li_etal_2010(zolrib, ri, za/z0, z0/zt)
+         !endif
+         !print*,"success,n=",n," ri=",ri," z0=",z0
+      endif
+
+      return
+      end function
+!====================================================================
+
+   subroutine psi_init(psi_opt,errmsg,errflg)
+
+    integer                       :: n,psi_opt
+    real                          :: zolf
+    character(len=*), intent(out) :: errmsg
+    integer, intent(out)          :: errflg
+
+    if (psi_opt == 0) then
+       do n=0,1000
+          ! stable function tables
+          zolf = float(n)*0.01
+          psim_stab(n)=psim_stable_full(zolf)
+          psih_stab(n)=psih_stable_full(zolf)
+
+          ! unstable function tables
+          zolf = -float(n)*0.01
+          psim_unstab(n)=psim_unstable_full(zolf)
+          psih_unstab(n)=psih_unstable_full(zolf)
+       enddo
+    else
+       do n=0,1000
+          ! stable function tables
+          zolf = float(n)*0.01
+          psim_stab(n)=psim_stable_full_gfs(zolf)
+          psih_stab(n)=psih_stable_full_gfs(zolf)
+
+          ! unstable function tables
+          zolf = -float(n)*0.01
+          psim_unstab(n)=psim_unstable_full_gfs(zolf)
+          psih_unstab(n)=psih_unstable_full_gfs(zolf)
+       enddo
+    endif
+
+    !simple test to see if initialization worked:
+    if (psim_stab(1) < 0. .and. psih_stab(1) < 0. .and. & 
+        psim_unstab(1) > 0. .and. psih_unstab(1) > 0.) then
+       errmsg = 'in mynn sfc, psi tables have been initialized'
+       errflg = 0
+    else
+       errmsg = 'error in mynn sfc: problem initializing psi tables'
+       errflg = 1
+    endif
+
+   end subroutine psi_init
+! ==================================================================
+! ... integrated similarity functions from mynn...
+!
+!>\ingroup mynn_sfc
+   real function psim_stable_full(zolf)
+        real :: zolf   
+
+        !psim_stable_full=-6.1*log(zolf+(1+zolf**2.5)**(1./2.5))
+        psim_stable_full=-6.1*log(zolf+(1+zolf**2.5)**0.4) 
+
+        return
+   end function
+
+!>\ingroup mynn_sfc
+   real function psih_stable_full(zolf)
+        real :: zolf
+
+        !psih_stable_full=-5.3*log(zolf+(1+zolf**1.1)**(1./1.1))
+        psih_stable_full=-5.3*log(zolf+(1+zolf**1.1)**0.9090909090909090909)
+
+        return
+   end function
+
+!>\ingroup mynn_sfc
+   real function psim_unstable_full(zolf)
+        real :: zolf,x,ym,psimc,psimk
+
+        x=(1.-16.*zolf)**.25
+        !psimk=2*alog(0.5*(1+x))+alog(0.5*(1+x*x))-2.*atan(x)+2.*atan(1.)
+        psimk=2.*alog(0.5*(1+x))+alog(0.5*(1+x*x))-2.*atan(x)+2.*atan1
+
+        ym=(1.-10.*zolf)**onethird
+        !psimc=(3./2.)*log((ym**2.+ym+1.)/3.)-sqrt(3.)*atan((2.*ym+1)/sqrt(3.))+4.*atan(1.)/sqrt(3.)
+        psimc=1.5*log((ym**2 + ym+1.)*onethird)-sqrt3*atan((2.*ym+1)/sqrt3)+4.*atan1/sqrt3
+
+        psim_unstable_full=(psimk+zolf**2*(psimc))/(1+zolf**2.)
+
+        return
+   end function
+
+!>\ingroup mynn_sfc
+   real function psih_unstable_full(zolf)
+        real :: zolf,y,yh,psihc,psihk
+
+        y=(1.-16.*zolf)**.5
+        !psihk=2.*log((1+y)/2.)
+        psihk=2.*log((1+y)*0.5)
+
+        yh=(1.-34.*zolf)**onethird
+        !psihc=(3./2.)*log((yh**2.+yh+1.)/3.)-sqrt(3.)*atan((2.*yh+1)/sqrt(3.))+4.*atan(1.)/sqrt(3.)
+        psihc=1.5*log((yh**2.+yh+1.)*onethird)-sqrt3*atan((2.*yh+1)/sqrt3)+4.*atan1/sqrt3
+
+        psih_unstable_full=(psihk+zolf**2*(psihc))/(1+zolf**2)
+
+        return
+   end function
+
+! ==================================================================
+! ... integrated similarity functions from gfs...
+!
+   real function psim_stable_full_gfs(zolf)
+        real :: zolf
+        real, parameter :: alpha4 = 20.
+        real :: aa
+
+        aa     = sqrt(1. + alpha4 * zolf)
+        psim_stable_full_gfs  = -1.*aa + log(aa + 1.)
+
+        return
+   end function
+
+   real function psih_stable_full_gfs(zolf)
+        real :: zolf
+        real, parameter :: alpha4 = 20.
+        real :: bb
+
+        bb     = sqrt(1. + alpha4 * zolf)
+        psih_stable_full_gfs  = -1.*bb + log(bb + 1.)
+
+        return
+   end function
+
+   real function psim_unstable_full_gfs(zolf)
+        real :: zolf
+        real :: hl1,tem1
+        real, parameter :: a0=-3.975,  a1=12.32,  &
+                           b1=-7.755,  b2=6.041
+
+        if (zolf .ge. -0.5) then
+           hl1   = zolf
+           psim_unstable_full_gfs  = (a0  + a1*hl1)  * hl1   / (1.+ (b1+b2*hl1)  *hl1)
+        else
+           hl1   = -zolf
+           tem1  = 1.0 / sqrt(hl1)
+           psim_unstable_full_gfs  = log(hl1) + 2. * sqrt(tem1) - .8776
+        end if
+
+        return
+   end function
+
+   real function psih_unstable_full_gfs(zolf)
+        real :: zolf
+        real :: hl1,tem1
+        real, parameter :: a0p=-7.941, a1p=24.75, &
+                           b1p=-8.705, b2p=7.899
+
+        if (zolf .ge. -0.5) then
+           hl1   = zolf
+           psih_unstable_full_gfs  = (a0p + a1p*hl1) * hl1   / (1.+ (b1p+b2p*hl1)*hl1)
+        else
+           hl1   = -zolf
+           tem1  = 1.0 / sqrt(hl1)
+           psih_unstable_full_gfs  = log(hl1) + .5 * tem1 + 1.386
+        end if
+
+        return
+   end function
+
+!=================================================================
+! look-up table functions - or, if beyond -10 < z/l < 10, recalculate
+!=================================================================
+   real function psim_stable(zolf,psi_opt)
+        integer :: nzol,psi_opt
+        real    :: rzol,zolf
+
+        nzol = int(zolf*100.)
+        rzol = zolf*100. - nzol
+        if(nzol+1 .lt. 1000)then
+           psim_stable = psim_stab(nzol) + rzol*(psim_stab(nzol+1)-psim_stab(nzol))
+        else
+           if (psi_opt == 0) then
+              psim_stable = psim_stable_full(zolf)
+           else
+              psim_stable = psim_stable_full_gfs(zolf)
+           endif
+        endif
+
+      return
+   end function
+
+   real function psih_stable(zolf,psi_opt)
+        integer :: nzol,psi_opt
+        real    :: rzol,zolf
+
+        nzol = int(zolf*100.)
+        rzol = zolf*100. - nzol
+        if(nzol+1 .lt. 1000)then
+           psih_stable = psih_stab(nzol) + rzol*(psih_stab(nzol+1)-psih_stab(nzol))
+        else
+           if (psi_opt == 0) then
+              psih_stable = psih_stable_full(zolf)
+           else
+              psih_stable = psih_stable_full_gfs(zolf)
+           endif
+        endif
+
+      return
+   end function
+
+   real function psim_unstable(zolf,psi_opt)
+        integer :: nzol,psi_opt
+        real    :: rzol,zolf
+
+        nzol = int(-zolf*100.)
+        rzol = -zolf*100. - nzol
+        if(nzol+1 .lt. 1000)then
+           psim_unstable = psim_unstab(nzol) + rzol*(psim_unstab(nzol+1)-psim_unstab(nzol))
+        else
+           if (psi_opt == 0) then
+              psim_unstable = psim_unstable_full(zolf)
+           else
+              psim_unstable = psim_unstable_full_gfs(zolf)
+           endif
+        endif
+
+      return
+   end function
+
+   real function psih_unstable(zolf,psi_opt)
+        integer :: nzol,psi_opt
+        real    :: rzol,zolf
+
+        nzol = int(-zolf*100.)
+        rzol = -zolf*100. - nzol
+        if(nzol+1 .lt. 1000)then
+           psih_unstable = psih_unstab(nzol) + rzol*(psih_unstab(nzol+1)-psih_unstab(nzol))
+        else
+           if (psi_opt == 0) then
+              psih_unstable = psih_unstable_full(zolf)
+           else
+              psih_unstable = psih_unstable_full_gfs(zolf)
+           endif
+        endif
+
+      return
+   end function
+!========================================================================
 end module module_sf_noahmplsm
 

--- a/physics/sfc_noahmp_drv.F90
+++ b/physics/sfc_noahmp_drv.F90
@@ -11,7 +11,11 @@
 !> This module contains the CCPP-compliant NoahMP land surface model driver.
       module noahmpdrv
 
+      use module_sf_noahmplsm
+
       implicit none
+
+      integer, parameter :: psi_opt = 0 ! 0: MYNN or 1:GFS
 
       private
 
@@ -27,6 +31,7 @@
 !!
       subroutine noahmpdrv_init(lsm, lsm_noahmp, me, isot, ivegsrc, &
                                 nlunit, pores, resid,               &
+                                do_mynnsfclay,do_mynnedmf,          &
                                 errmsg, errflg)
 
         use machine,          only: kind_phys
@@ -39,6 +44,10 @@
         integer,              intent(in)  :: me, isot, ivegsrc, nlunit
 
         real (kind=kind_phys), dimension(:), intent(out) :: pores, resid
+
+        logical,              intent(in) :: do_mynnsfclay
+        logical,              intent(in) :: do_mynnedmf
+
 
         character(len=*),     intent(out) :: errmsg
         integer,              intent(out) :: errflg
@@ -68,8 +77,30 @@
           return
         end if
 
+        if (.not. do_mynnsfclay .and. do_mynnedmf) then
+          errmsg = 'Problem : do_mynnsfclay = .false.' // &
+                   'but mynnpbl is .true.. Exiting ...'
+          errflg = 1
+          return
+        end if
+
+        if ( do_mynnsfclay .and. .not. do_mynnedmf) then
+          errmsg = 'Problem : do_mynnsfclay = .true.' // &
+                   'but mynnpbl is .false.. Exiting ...'
+          errflg = 1
+          return
+        end if
+
+
         !--- initialize soil vegetation
         call set_soilveg(me, isot, ivegsrc, nlunit)
+
+
+        ! initialize psih and psim 
+
+        if ( do_mynnsfclay ) then
+        call psi_init(psi_opt,errmsg,errflg)
+        endif
 
         pores (:) = maxsmc (:)
         resid (:) = drysmc (:)
@@ -107,7 +138,7 @@
 !  ---  inputs:
     ( im, km, lsnowl, itime, ps, u1, v1, t1, q1, soiltyp,        &
       vegtype, sigmaf, dlwflx, dswsfc, snet, delt, tg3, cm, ch,  &
-      prsl1, prslk1, prslki, prsik1, zf, dry, wind, slopetyp,    &
+      prsl1, prslk1, prslki, prsik1, zf,pblh, dry, wind, slopetyp,    &
       shdmin, shdmax, snoalb, sfalb, flag_iter,con_g,            &
       idveg, iopt_crs, iopt_btr, iopt_run, iopt_sfc, iopt_frz,   &
       iopt_inf, iopt_rad, iopt_alb, iopt_snf, iopt_tbot,         &
@@ -120,6 +151,7 @@
       weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        &
       canopy, trans, tsurf, zorl,                                &
       rb1, fm1, fh1, ustar1, stress1, fm101, fh21,               &
+      rmol1,flhc1,flqc1,do_mynnsfclay,                           &
 
 ! --- Noah MP specific
 
@@ -140,7 +172,7 @@
   use funcphys,   only : fpvs
 
   use sfc_diff,   only : stability
-  use module_sf_noahmplsm
+! use module_sf_noahmplsm
   use module_sf_noahmp_glacier
   use noahmp_tables, only : isice_table, co2_table, o2_table,            &
                             isurban_table, smcref_table, smcdry_table,   &
@@ -159,6 +191,8 @@
 
   integer, parameter               :: nsoil   = 4   ! hardwired to Noah
   integer, parameter               :: nsnow   = 3   ! max. snow layers
+
+  integer, parameter               :: iz0tlnd = 0   ! z0t treatment option
 
   real(kind=kind_phys), save  :: zsoil(nsoil)
   data zsoil  / -0.1, -0.4, -1.0, -2.0 /
@@ -193,6 +227,15 @@
   real(kind=kind_phys), dimension(:)     , intent(in)    :: prsik1     ! Exner function at the ground surfac
 
   real(kind=kind_phys), dimension(:)     , intent(in)    :: zf         ! height of bottom layer [m]
+
+  logical                                , intent(in)    :: do_mynnsfclay !flag for MYNN sfc layer scheme
+
+  real(kind=kind_phys), dimension(:)     , intent(in)    :: pblh       ! height of pbl
+  real(kind=kind_phys), dimension(:)     , intent(inout) :: rmol1      !
+  real(kind=kind_phys), dimension(:)     , intent(inout) :: flhc1      !
+  real(kind=kind_phys), dimension(:)     , intent(inout) :: flqc1      !
+
+
   logical             , dimension(:)     , intent(in)    :: dry        ! = T if a point with any land
   real(kind=kind_phys), dimension(:)     , intent(in)    :: wind       ! wind speed [m/s]
   integer             , dimension(:)     , intent(in)    :: slopetyp   ! surface slope classification
@@ -505,6 +548,16 @@
   real (kind=kind_phys)                            :: prsik1x               !  in exner function
   real (kind=kind_phys)                            :: prslk1x               !  in exner function
 
+  real (kind=kind_phys)                            :: ch2
+  real (kind=kind_phys)                            :: cq2
+  real (kind=kind_phys)                            :: qfx
+  real (kind=kind_phys)                            :: wspd1                 !  wind speed with all components
+  real (kind=kind_phys)                            :: pblhx                 !  height of pbl
+
+  real (kind=kind_phys)                            :: rah_total             !
+  real (kind=kind_phys)                            :: cah_total             !
+
+
 !
 !  ---  local variable
 !
@@ -593,6 +646,8 @@ do i = 1, im
       uwind_forcing         = u1(i)
       vwind_forcing         = v1(i)
       area_grid             = garea(i)
+
+      pblhx                 = pblh(i)
 
       prslkix               = prslki(i)
       prsik1x               = prsik1(i)
@@ -725,7 +780,8 @@ do i = 1, im
           spec_humidity_forcing,sw_radiation_forcing ,precipitation_forcing,radiation_lw_forcing , &
           temperature_soil_bot ,forcing_height       ,snow_ice_frac_old    ,zsoil                , &
           thsfc_loc            ,prslkix              ,prsik1x              ,prslk1x              , &
-	  vegetation_frac      ,area_grid            ,                                             &
+          air_pressure_surface ,pblhx                ,iz0tlnd              ,itime                , &
+	  vegetation_frac      ,area_grid            ,psi_opt                                    , &
           snowfall             ,snow_water_equiv_old ,snow_albedo_old      ,                       &
           cm_noahmp            ,ch_noahmp            ,snow_levels          ,snow_water_equiv     , &
           soil_moisture_vol    ,interface_depth      ,snow_depth           ,snow_level_ice       , &
@@ -804,6 +860,8 @@ do i = 1, im
           spec_humidity_forcing ,area_grid             ,cloud_water_forcing   , &
           sw_radiation_forcing  ,radiation_lw_forcing  ,thsfc_loc             , &
           prslkix               ,prsik1x               ,prslk1x               , &
+          pblhx                 ,iz0tlnd               ,itime                 , &
+          psi_opt                                                             , &
           precip_convective                                                   , &
           precip_non_convective ,precip_sh_convective  ,precip_snow           , &
           precip_graupel        ,precip_hail           ,temperature_soil_bot  , &
@@ -923,7 +981,7 @@ do i = 1, im
       snowc     (i)   = snow_cover_fraction
       sncovr1   (i)   = snow_cover_fraction
 
-      qsurf     (i)   = spec_humidity_surface
+!     qsurf     (i)   = spec_humidity_surface
       tsurf     (i)   = tskin(i)
 
       tvxy      (i)   = temperature_leaf
@@ -986,10 +1044,48 @@ do i = 1, im
             zvfun(i) = sqrt(tem1 * tem2)
             gdx=sqrt(garea(i))
 
+       if ( .not. do_mynnsfclay) then   !GFS sfcdiff
+
       call       stability                                                               &
         (zf(i), zvfun(i), gdx, virtual_temperature, vptemp,wind(i), z0_total, z0h_total, & 
          tvs1, con_g, thsfc_loc,                                                         &
          rb1(i), fm1(i), fh1(i), fm101(i), fh21(i), cm(i), ch(i), stress1(i), ustar1(i))
+
+       rmol1(i) = undefined  !not used in GFS sfcdif -> to satsify output
+       flhc1(i) = undefined
+       flqc1(i) = undefined
+
+        rah_total = max(1.0,1.0/( ch(i)*wind(i)) )
+        cah_total = density * con_cp /rah_total
+!       tskin(i) = sensible_heat_total/cah_total + temperature_forcing ! test to use combined ch and SH to backout Ts
+
+         ch(i) = ch_vegetated * vegetation_frac + ch_bare_ground*(1.0-vegetation_frac)
+
+      else    ! MYNN - note the GFS option is the same as sfcdif3; so removed.
+
+             qfx = evap(i) / con_hvap         ! use flux from output
+
+           call sfcdif4(i_location  ,j_location  ,uwind_forcing ,vwind_forcing ,           &
+                        temperature_forcing, air_pressure_forcing ,air_pressure_surface  , &
+                        pblhx,gdx,z0_total,itime,snwdph(i),0,psi_opt,surface_temperature,  &
+                        spec_humidity_forcing,forcing_height,iz0tlnd,spec_humidity_surface,&
+                        sensible_heat_total,qfx,cm(i),ch(i),ch2,cq2,rmol1(i),ustar1(i),    &
+                        rb1(i),fm1(i),fh1(i),stress1(i),fm101(i),fh21(i),wspd1,flhc1(i),   &
+                        flqc1(i) )
+
+              ch(i)=ch(i)/wspd1
+              cm(i)=cm(i)/wspd1
+
+              ch(i) = ch_vegetated * vegetation_frac + ch_bare_ground*(1.0-vegetation_frac)
+
+          rah_total = max(1.0,1.0/( ch(i)*wind(i)) )
+          cah_total = density * con_cp /rah_total
+
+!          tskin(i) = sensible_heat_total/cah_total + temperature_forcing !
+
+       endif
+
+
 
       cmxy(i) = cm(i)
       chxy(i) = ch(i)
@@ -998,7 +1094,7 @@ do i = 1, im
       cmm       (i)   = cmxy(i)  * wind(i)
 
       snwdph    (i)   = snow_depth * 1000.0       ! convert from m to mm; wait after the stability call
-!     qsurf     (i)   = q1(i) + evap(i)/(con_hvap*density*ch(i)*wind(i))
+      qsurf     (i)   = q1(i) + evap(i)/(con_hvap*density*ch(i)*wind(i))
 
 !      
 !  --- change units for output

--- a/physics/sfc_noahmp_drv.meta
+++ b/physics/sfc_noahmp_drv.meta
@@ -65,6 +65,20 @@
   type = real
   intent = out
   kind = kind_phys
+[do_mynnsfclay]
+  standard_name = flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme
+  long_name = flag to activate MYNN surface layer
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[do_mynnedmf]
+  standard_name = flag_for_mellor_yamada_nakanishi_niino_pbl_scheme
+  long_name = flag to activate MYNN-EDMF
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
@@ -266,6 +280,14 @@
 [zf]
   standard_name = height_above_ground_at_lowest_model_layer
   long_name = layer 1 height above ground (not MSL)
+  units = m
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[pblh]
+  standard_name = atmosphere_boundary_layer_thickness
+  long_name = PBL thickness
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
@@ -741,6 +763,37 @@
   type = real
   kind = kind_phys
   intent = inout
+[rmol1]
+  standard_name = reciprocal_of_obukhov_length
+  long_name = one over obukhov length
+  units = m-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[flhc1]
+  standard_name = surface_exchange_coefficient_for_heat
+  long_name = surface exchange coefficient for heat
+  units = W m-2 K-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[flqc1]
+  standard_name = surface_exchange_coefficient_for_moisture
+  long_name = surface exchange coefficient for moisture
+  units = kg m-2 s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[do_mynnsfclay]
+  standard_name = flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme
+  long_name = flag to activate MYNN surface layer
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [snowxy]
   standard_name = number_of_snow_layers
   long_name = number of snow layers


### PR DESCRIPTION
I have included the MYNN sfc scheme as 'iopt_sfc' = 4 on the top of the latest land updates (for p8c) in Noah MP. It involves 4 files: 1) the driver meta file, driver, glacier and non-glacier subroutines. The inclusion is done with 3 separate commits - 1) driver and meta; 2) the glacier changes, and 3) non-glacier changes. The initial inclusion was based on the RRFS code (from NCAR ccpp-physics - about end of January). The RRFS code does not have the new option 'opt_trs' so I can't test the new adapted code. I think it should compile ok. Let me know if you have questions. Thanks.